### PR TITLE
Fixes: Use pandoc for markdown to html conversion.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,12 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 url: "" # the base hostname & protocol for your site
 
 # Build settings
-markdown: kramdown
+markdown: pandoc
 highlighter: pygments
 
+gems:
+ - jekyll-pandoc
+
+pandoc:
+ extensions:
+  - smart


### PR DESCRIPTION
Problem: I need to use pandoc to convert markdown files to html files.

Analysis: I added commands to the jekyll _config.yml file that tell it to use pandoc as the markdown converter.

Unit/Robot tests:
