### PR TITLE
fix image sizing in deploy/install guides

### DIFF
--- a/_includes/m_install_lbaas_plugin_agent.md
+++ b/_includes/m_install_lbaas_plugin_agent.md
@@ -47,7 +47,7 @@ Table 1.<a name="Table1"></a>
 
 **Figure 1.** 
 
-<img src="{{ "/f5-os-lbaasv1/lbaas-agent-status.png" | prepend: site.baseurl | prepend: site.url }}" alt="Figure 1"/>
+<img src="{{ "/f5-os-lbaasv1/lbaas-agent-status.png" | prepend: site.baseurl | prepend: site.url }}" alt="Figure 1" width="500"/>
 
 {% include /f5-os-lbaasv1/t_install_agent_check_status_note.md %}
 

--- a/_includes/m_install_lbaas_plugin_driver.md
+++ b/_includes/m_install_lbaas_plugin_driver.md
@@ -4,7 +4,7 @@
 
 {% include /f5-os-lbaasv1/t_sample_environment_diagram_explained.md %}
 
-<img src="{{ "/f5-os-lbaasv1/openstack_lbaas_env_example.png" | prepend: site.baseurl | prepend: site.url }}" alt="Figure 1" />
+<img src="{{ "/f5-os-lbaasv1/openstack_lbaas_env_example.png" | prepend: site.baseurl | prepend: site.url }}" alt="Figure 1" width="500px" />
 
 ## Prerequisites
 

--- a/_includes/m_lbaasv1_plugin_deploy_guide.md
+++ b/_includes/m_lbaasv1_plugin_deploy_guide.md
@@ -30,7 +30,7 @@
 
 {% include /f5-os-lbaasv1/t_sample_environment_diagram_explained.md %}
 
-![]({{ "/f5-os-lbaasv1/openstack_lbaas_env_example.png" | prepend: site.baseurl | prepend: site.url }} "Figure 1")
+<img src="{{ "/f5-os-lbaasv1/openstack_lbaas_env_example.png" | prepend: site.baseurl | prepend: site.url }}" alt="Figure 1" width="500">
 
 #### RedHat/CentOS
 
@@ -83,7 +83,7 @@ Complete both of the installation steps \(install, then stop\) on each host on w
 
 Figure 2. 
 
-![]({{ "/f5-os-lbaasv1/lbaas-agent-status.png" | prepend: site.baseurl | prepend: site.url }} "Figure 2")
+<img src="{{ "/f5-os-lbaasv1/lbaas-agent-status.png" | prepend: site.baseurl | prepend: site.url }}" alt="Figure 2" width="500">
 
 {% include /f5-os-lbaasv1/t_install_agent_check_status_note.md %}
 


### PR DESCRIPTION
As noted above -- fixes the image size in the following:
- How to Install the F5 OpenStack LBaaSv1 Plugin Agent
- How to Install the F5 OpenStack LBaaSv1 Plugin Driver
- Using the F5 OpenStack LBaaSv1 Plugin and BIG-IP to Manage Local Traffic in OpenStack
