### PR TITLE
Compatibility matrix update

### DIFF
--- a/_includes/f5-os-lbaasv1/t_driver_prerequisites.md
+++ b/_includes/f5-os-lbaasv1/t_driver_prerequisites.md
@@ -13,5 +13,5 @@ To use the F5 OpenStack LBaaSv1 plugin, you'll need:
 1. Licensed BIG-IP hardware or Virtual Edition (VE). 
 2. Administrator priveleges on BIG-IP and any associated device clusters. 
 
-See the [F5 OpenStack LBaaS compatibility matrix]({{ /compatibility-matrix/ | prepend: site.baseurl | prepend: site.url }}) for information regarding various distributions' compatibility with the F5 OpenStack LBaaSv1 Plugin and BIG-IP. 
+
 

--- a/_includes/m_install_lbaas_plugin_agent.md
+++ b/_includes/m_install_lbaas_plugin_agent.md
@@ -1,4 +1,4 @@
-# Overview
+## Overview
 
 {% include /f5-os-lbaasv1/t_agent_overview.md %}
 

--- a/_includes/m_install_lbaas_plugin_driver.md
+++ b/_includes/m_install_lbaas_plugin_driver.md
@@ -1,4 +1,4 @@
-# Overview
+## Overview
 
 {% include /f5-os-lbaasv1/t_driver_overview.md %}
 
@@ -10,37 +10,41 @@
 
 {% include /f5-os-lbaasv1/t_driver_prerequisites.md %}
 
-# Tasks
+## Compatibility
 
-## Install the F5 OpenStack LBaaSv1 Plugin Driver
+{% include r_compatibility_matrix.md %}
+
+## Tasks
+
+### Install the F5 OpenStack LBaaSv1 Plugin Driver
 
 {% include /f5-os-lbaasv1/t_install_driver_overview.md %}
 
-### RedHat/CentOS
+#### RedHat/CentOS
 
 {% include //f5-os-lbaasv1/t_install_driver_neutron_server_redhat-centos.md %}
 
-### Ubuntu
+#### Ubuntu
 
 {% include /f5-os-lbaasv1/t_install_driver_neutron_server_ubuntu.md %}
 
 {% include /f5-os-lbaasv1/t_install_driver_neutron_server_overview-note.md %}
 
-## Configure the Neutron Service to use the F5 LBaaSv1 Plugin
+### Configure the Neutron Service to use the F5 LBaaSv1 Plugin
 
 {% include /f5-os-lbaasv1/t_install_driver_neutron_server_set-default-lbaas-service.md %}
 
-### RedHat/CentOS
+#### RedHat/CentOS
 
 {% include /f5-os-lbaasv1/t_install_driver_neutron_server_redhat-centos.md %}
 
-### Ubuntu
+#### Ubuntu
 
 {% include /f5-os-lbaasv1/t_install_driver_neutron_server_ubuntu.md %}
 
 1. Save the changes to the Neutron server config file.
 
-## Restart the Neutron Server
+### Restart the Neutron Server
 
 {% include /f5-os-lbaasv1/t_install_driver_neutron_server_restart-ubuntu.md %}
 

--- a/_includes/m_lbaasv1_plugin_deploy_guide.md
+++ b/_includes/m_lbaasv1_plugin_deploy_guide.md
@@ -2,6 +2,10 @@
 
 {% include /f5-os-lbaasv1/t_driver_overview.md %}
 
+## Compatibility
+
+{% include r_compatibility_matrix.md %}
+
 {% comment %}# Prerequisites
 
  tbd {% endcomment %}

--- a/_includes/r_compatibility_matrix.md
+++ b/_includes/r_compatibility_matrix.md
@@ -1,0 +1,10 @@
+## F5 OpenStack LBaaS Plugin Compatibility
+
+OpenStack release | LBaaS version | Supported Plugin version | BIG-IP version
+|:---|---:|---:|
+Mitaka | LBaaS v2 (coming soon!) | N/A | N/A
+Liberty | LBaaS v1 (coming soon!) | N/A | N/A 
+Kilo | LBaaS v1 | 1.0.10 | 11.5.x; 11.6.x; 12.0.x
+Juno | LBaaS v1 | 1.0.10 | 11.5.x; 11.6.x; 12.0.x
+Icehouse | LBaaS v1 | 1.0.10 | 11.5.x; 11.6.x; 12.0.x
+Havana | LBaaS v1| 1.0.10 | 11.5.x; 11.6.x; 12.0.x

--- a/compatibility-matrix.md
+++ b/compatibility-matrix.md
@@ -1,9 +1,0 @@
-
-Release | Date | F5 LBaaSv1 Compatible | BIG-IP Compatible Version\(s\)
-|:-:|:-:|
-Mitaka  | April 2016 | Not Released
-Liberty | October 2015 | Untested
-Kilo | April 2015  | Supported 1.0.10
-Icehouse | October 2014 | Supported 1.0.10
-Havana | April 2014 | Supported 1.0.10
-


### PR DESCRIPTION
@mattgreene 
#### What's this change do?

Updates to the compatibility matrix table.
- moved the file to _includes folder for reuse
- renamed according to TBA naming conventions (added the 'r_' designation)
- edited table for clarity
- added compatibility matrix to install/deploy guides
#### Where should the reviewer start?

Look at the file _includes/r_compatibility_matrix.md. 
The table is also used in the plugin driver installation doc and the lbaasv1_plugin_deploy_guide.
(links forthcoming)
#### Any background context?
