### PR TITLE
Add support/versioning page

### DIFF
--- a/releases_and_versioning.md
+++ b/releases_and_versioning.md
@@ -1,0 +1,101 @@
+---
+layout: default
+title: F5 OpenStack Releases and Support Matrix
+lbaas-version: 1
+tags: openstack, releases, versioning, lbaas, big-ip, plugin
+---
+
+# F5 OpenStack Releases and Support Matrix
+<br>
+
+## Releases and Versioning
+
+As shown in the table below, the version number for F5's OpenStack projects correspond to specific OpenStack releases. 
+
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:6px 9px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:6px 9px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
+.tg .tg-by3v{font-weight:bold;font-size:14px;text-align:center}
+.tg .tg-4996{font-size:14px;text-align:right;vertical-align:top}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-by3v">F5  Version</th>
+    <th class="tg-by3v">OpenStack Release</th>
+  </tr>
+  <tr>
+    <td class="tg-4996">1.x.x</td>
+    <td class="tg-4996">Kilo</td>
+  </tr>
+  <tr>
+    <td class="tg-4996">2.x.x</td>
+    <td class="tg-4996">Liberty</td>
+  </tr>
+  <tr>
+    <td class="tg-4996">3.x.x</td>
+    <td class="tg-4996">Mitaka</td>
+  </tr>
+</table>
+<br>
+
+## Support and Compatibility
+
+<style type="text/css">
+.tg  {border-collapse:collapse;border-spacing:0;}
+.tg td{font-family:Arial, sans-serif;font-size:14px;padding:11px 7px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
+.tg th{font-family:Arial, sans-serif;font-size:14px;font-weight:normal;padding:11px 7px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
+.tg .tg-by3v{font-weight:bold;font-size:14px;text-align:center}
+.tg .tg-62xo{font-weight:bold;font-size:14px;text-align:center;vertical-align:top}
+.tg .tg-4996{font-size:14px;text-align:right;vertical-align:bottom;}
+</style>
+<table class="tg">
+  <tr>
+    <th class="tg-by3v">OpenStack release</th>
+    <th class="tg-by3v">LBaaS version</th>
+    <th class="tg-62xo">Supported Plugin <br></th>
+    <th class="tg-62xo">BIG-IP</th>
+    <th class="tg-62xo">Red Hat / CentOS</th>
+    <th class="tg-62xo">Ubuntu</th>
+  </tr>
+  <tr>
+    <td class="tg-4996">Mitaka</td>
+    <td class="tg-4996">N/A</td>
+    <td class="tg-4996">N/A</td>
+    <td class="tg-4996">N/A</td>
+    <td class="tg-4996">N/A</td>
+    <td class="tg-4996">N/A</td>
+  </tr>
+  <tr>
+    <td class="tg-4996">Liberty</td>
+    <td class="tg-4996">LBaaS v1</td>
+    <td class="tg-4996">2.0.1</td>
+    <td class="tg-4996">11.5.x; 11.6.x; 12.0.x</td>
+    <td class="tg-4996">6, 7</td>
+    <td class="tg-4996">12, 14</td>
+  </tr>
+  <tr>
+    <td class="tg-4996">Kilo</td>
+    <td class="tg-4996">LBaaS v1</td>
+    <td class="tg-4996">1.0.12</td>
+    <td class="tg-4996">11.5.x; 11.6.x; 12.0.x</td>
+    <td class="tg-4996">6, 7</td>
+    <td class="tg-4996">12, 14</td>
+  </tr>
+  <tr>
+    <td class="tg-4996">Juno</td>
+    <td class="tg-4996">LBaaS v1</td>
+    <td class="tg-4996">1.0.12</td>
+    <td class="tg-4996">11.5.x; 11.6.x; 12.0.x</td>
+    <td class="tg-4996">6, 7</td>
+    <td class="tg-4996">12, 14</td>
+  </tr>
+  <tr>
+    <td class="tg-4996">Icehouse</td>
+    <td class="tg-4996">LBaaS v1</td>
+    <td class="tg-4996">1.0.12</td>
+    <td class="tg-4996">11.5.x; 11.6.x; 12.0.x</td>
+    <td class="tg-4996">6, 7</td>
+    <td class="tg-4996">12, 14</td>
+  </tr>
+</table>


### PR DESCRIPTION
@swormke 

Fixes #63
#### What's this change do?

I added a page that contains the version/release strategy details and the support/compatibility matrix. This page can be linked to from the individual project repos with the URL http://f5networks.githib.io/f5-openstack-docs/releases_and_versioning/.
#### Where should the reviewer start?

You can look at the rendered table via the View button; the css formatting will display on that page, but it doesn't appear when the page is rendered.
#### Any background context?
