### PR TITLE
Formatting and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ _build_html
 venv/*
 .venv
 .idea/*
-
+docs/venv/*

--- a/docs/guides/deploy_ve_openstack.rst
+++ b/docs/guides/deploy_ve_openstack.rst
@@ -1,4 +1,4 @@
-.. title:: Deploying BIG-IP VE in OpenStack
+.. _deploy_big-ip_openstack:
 
 Deploying BIG-IP VE in OpenStack
 ================================
@@ -33,65 +33,57 @@ Create VLANs
 
 .. include:: includes/os_ve_creating_vlans.rst
 
-External
-````````
+For each network you need to create, take the steps below.
 
-.. include:: includes/os_ve_base_networking-external.rst
+- .. include:: includes/os_create_network.rst
+- .. include:: includes/os_create_subnet.rst
+- .. include:: includes/os_attach_net_to_router.rst
 
-Internal
-````````
+**Example**: Create an external network and subnet for the BIG-IP, and attach them to the public-facing router.
 
-.. include:: includes/os_ve_base_networking-internal.rst
+    .. include:: includes/example_create_external_network.rst
 
-Management
-``````````
+    .. include:: includes/example_create_external_subnet.rst
 
-.. include:: includes/os_ve_deploy_config-mgmt-network.rst
+    .. include:: includes/example_create_external_network.rst
+
 
 SR-IOV
 ``````
-
 .. include:: includes/os_ve_sr-iov.rst
 
 Device Service Clustering
 `````````````````````````
-
 .. include:: includes/ve_clustering_overview.rst
 
 Create Custom Flavors
 ---------------------
-
 For information regarding BIG-IP VE image sizes and minimum requirements, see :ref:`BIG-IP VE Flavor Requirements <big-ip_flavors>`.
 
 .. include:: includes/os_ve_create-flavor-instructions.rst
 
 Deploy BIG-IP VE
 ----------------
-
 .. include:: includes/os_ve_deploy-big-ip.rst
 
 .. _import-ve-image:
 
 Import the VE Image
 ~~~~~~~~~~~~~~~~~~~
-
 .. include:: includes/os_import_ve_image.rst
 
 .. _launch_big-ip_instance:
 
 Launch the BIG-IP Instance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 .. include:: includes/os_ve_launch_instance.rst
 
 Assign a Floating IP
 ~~~~~~~~~~~~~~~~~~~~
-
 .. include:: includes/os_ve_assign-floating-ip.rst
 
 Next Steps
 ----------
-
 .. include:: includes/os_ve_deploy_big-ip_next-steps.rst
 
 .. _further_reading:

--- a/docs/guides/includes/deploy_ve_init_setup.rst
+++ b/docs/guides/includes/deploy_ve_init_setup.rst
@@ -2,22 +2,21 @@
 
 1. Create projects, roles, and users as needed. At minimum, create an admin project and role; then, create an admin user and assign to it the admin role and project.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # openstack project create admin
-        # openstack role create admin
-        # openstack user create admin --project=admin --password=default --email=<email_address> --role=admin
+    # openstack project create admin
+    # openstack role create admin
+    # openstack user create admin --project=admin --password=default --email=<email_address> --role=admin
 
 2. Create a security group for the BIG-IP.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # neutron security-group-create BIG-IP_default
-
+    # neutron security-group-create BIG-IP_default
 
 3. Add incoming traffic policies to the security group.
 
-   -  ICMP
+    ICMP
 
     .. code-block:: text
 
@@ -38,7 +37,7 @@
         | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec     |
         +-------------------+--------------------------------------+
 
-   -  SSH
+    SSH
 
     .. code-block:: text
 
@@ -59,7 +58,7 @@
         | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec     |
         +-------------------+--------------------------------------+
 
-   - HTTP
+    HTTP
 
     .. code-block:: text
 
@@ -80,7 +79,7 @@
         | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec     |
         +-------------------+--------------------------------------+
 
-   - SSL
+    SSL
 
     .. code-block:: text
 
@@ -101,7 +100,7 @@
         | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec     |
         +-------------------+--------------------------------------+
 
-   - VXLAN
+    VXLAN
 
     .. code-block:: text
 
@@ -122,7 +121,7 @@
         | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec     |
         +-------------------+--------------------------------------+
 
-   - GRE
+    GRE
 
     .. code-block:: text
 
@@ -145,29 +144,28 @@
 
 4. Check/Add Package Information
 
-    BIG-IP needs to be able to detect that it’s running on a VM. Check :file:`/etc/nova/release` to make sure that the vendor, product, and package information is stored there.
+BIG-IP needs to be able to detect that it’s running on a VM. Check :file:`/etc/nova/release` to make sure that the vendor, product, and package information is stored there.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # cat /etc/nova/release
-        [Nova]
-        vendor = Fedora Project
-        product = OpenStack Nova
-        package = 1.el7
+    # cat /etc/nova/release
+    [Nova]
+    vendor = Fedora Project
+    product = OpenStack Nova
+    package = 1.el7
 
 
-    If the package information isn't present, enter the appropriate information for your environment.
+If the package information isn't present, enter the appropriate information for your environment.
 
-    Example:
+Example:
 
-    .. code-block:: text
+.. code-block:: text
 
-        # echo -e "[Nova]\nvendor = Fedora Project\nproduct = OpenStack Nova\npackage = 1.el7" > /etc/nova/release
-
+    # echo -e "[Nova]\nvendor = Fedora Project\nproduct = OpenStack Nova\npackage = 1.el7" > /etc/nova/release
 
 5. Restart the Nova-Compute Service
 
-    .. code-block:: text
+.. code-block:: text
 
-        # service nova-compute restart
+    # service nova-compute restart
 

--- a/docs/guides/includes/example_attach_internal_subnet_router.rst
+++ b/docs/guides/includes/example_attach_internal_subnet_router.rst
@@ -1,0 +1,5 @@
+.. code-block:: text
+
+    # neutron router-interface-add router1 bigip_internal_subnet
+    Added interface 20a6a00c-6708-4f73-a94f-76d86d518c4c to router router1.
+

--- a/docs/guides/includes/example_attach_subnet_router.rst
+++ b/docs/guides/includes/example_attach_subnet_router.rst
@@ -1,0 +1,5 @@
+.. code-block:: text
+
+    # neutron router-interface-add router1 bigip_external_subnet
+    Added interface 2593c3be-fbc5-453c-901f-1d1d33b09951 to router router1.
+

--- a/docs/guides/includes/example_create_external_network.rst
+++ b/docs/guides/includes/example_create_external_network.rst
@@ -1,0 +1,20 @@
+.. code-block:: text
+
+    # neutron net-create bigip_external
+    Created a new network:
+    +---------------------------+--------------------------------------+
+    | Field                     | Value                                |
+    +---------------------------+--------------------------------------+
+    | admin_state_up            | True                                 |
+    | id                        | 05f61e74-37e0-4c30-a664-762dfef1a221 |
+    | mtu                       | 0                                    |
+    | name                      | bigip_external                       |
+    | provider:network_type     | vxlan                                |
+    | provider:physical_network |                                      |
+    | provider:segmentation_id  | 84                                   |
+    | router:external           | False                                |
+    | shared                    | False                                |
+    | status                    | ACTIVE                               |
+    | subnets                   |                                      |
+    | tenant_id                 | 1a35d6558b59423e83f4500f1ebc1cec     |
+    +---------------------------+--------------------------------------+

--- a/docs/guides/includes/example_create_external_subnet.rst
+++ b/docs/guides/includes/example_create_external_subnet.rst
@@ -1,0 +1,22 @@
+.. code-block:: text
+
+    # neutron subnet-create --name bigip_external_subnet bigip_external 10.20.0.0/24
+    Created a new subnet:
+    +-------------------+----------------------------------------------+
+    | Field             | Value                                        |
+    +-------------------+----------------------------------------------+
+    | allocation_pools  | {"start": "10.20.0.2", "end": "10.20.0.254"} |
+    | cidr              | 10.20.0.0/24                                 |
+    | dns_nameservers   |                                              |
+    | enable_dhcp       | True                                         |
+    | gateway_ip        | 10.20.0.1                                    |
+    | host_routes       |                                              |
+    | id                | ac966870-2165-4576-9f70-dcf4193e7c39         |
+    | ip_version        | 4                                            |
+    | ipv6_address_mode |                                              |
+    | ipv6_ra_mode      |                                              |
+    | name              | bigip_external_subnet                        |
+    | network_id        | 05f61e74-37e0-4c30-a664-762dfef1a221         |
+    | subnetpool_id     |                                              |
+    | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec             |
+    +-------------------+----------------------------------------------+

--- a/docs/guides/includes/example_create_internal_network.rst
+++ b/docs/guides/includes/example_create_internal_network.rst
@@ -1,0 +1,20 @@
+.. code-block:: text
+
+    # neutron net-create bigip_internal
+    Created a new network:
+    +---------------------------+--------------------------------------+
+    | Field                     | Value                                |
+    +---------------------------+--------------------------------------+
+    | admin_state_up            | True                                 |
+    | id                        | e707fe41-3a36-4e15-b521-53496e36e2e0 |
+    | mtu                       | 0                                    |
+    | name                      | bigip_internal                       |
+    | provider:network_type     | vxlan                                |
+    | provider:physical_network |                                      |
+    | provider:segmentation_id  | 63                                   |
+    | router:external           | False                                |
+    | shared                    | False                                |
+    | status                    | ACTIVE                               |
+    | subnets                   |                                      |
+    | tenant_id                 | 1a35d6558b59423e83f4500f1ebc1cec     |
+    +---------------------------+--------------------------------------+

--- a/docs/guides/includes/example_create_private_subnet.rst
+++ b/docs/guides/includes/example_create_private_subnet.rst
@@ -1,0 +1,22 @@
+.. code-block:: text
+
+    # neutron subnet-create --name bigip_internal_subnet bigip_internal 10.30.0.0/24
+    Created a new subnet:
+    +-------------------+----------------------------------------------+
+    | Field             | Value                                        |
+    +-------------------+----------------------------------------------+
+    | allocation_pools  | {"start": "10.30.0.2", "end": "10.30.0.254"} |
+    | cidr              | 10.30.0.0/24                                 |
+    | dns_nameservers   |                                              |
+    | enable_dhcp       | True                                         |
+    | gateway_ip        | 10.30.0.1                                    |
+    | host_routes       |                                              |
+    | id                | f4a01d74-730e-428a-8722-f2fe94346f87         |
+    | ip_version        | 4                                            |
+    | ipv6_address_mode |                                              |
+    | ipv6_ra_mode      |                                              |
+    | name              | bigip_internal_subnet                        |
+    | network_id        | e707fe41-3a36-4e15-b521-53496e36e2e0         |
+    | subnetpool_id     |                                              |
+    | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec             |
+    +-------------------+----------------------------------------------+

--- a/docs/guides/includes/os_attach_net_to_router.rst
+++ b/docs/guides/includes/os_attach_net_to_router.rst
@@ -1,0 +1,6 @@
+Attach the subnet to the router.
+
+.. code-block:: text
+
+    # neutron router-interface-add <router_name> <subnet_name>
+

--- a/docs/guides/includes/os_create_network.rst
+++ b/docs/guides/includes/os_create_network.rst
@@ -1,0 +1,6 @@
+Create a new network.
+
+.. code-block:: text
+
+    # neutron net-create <network_name>
+

--- a/docs/guides/includes/os_create_router.rst
+++ b/docs/guides/includes/os_create_router.rst
@@ -1,0 +1,6 @@
+Create a router.
+
+.. code-block:: text
+
+    # neutron router-create <router_name>
+

--- a/docs/guides/includes/os_create_subnet.rst
+++ b/docs/guides/includes/os_create_subnet.rst
@@ -1,0 +1,6 @@
+Create a subnet.
+
+.. code-block:: text
+
+    # neutron subnet-create --name <subnet_name> <network_name> <CIDR>
+

--- a/docs/guides/includes/os_import_ve_image.rst
+++ b/docs/guides/includes/os_import_ve_image.rst
@@ -2,14 +2,17 @@
 
 To import a VE image file using the command line:
 
-    .. code-block:: text
+.. code-block:: text
 
-        $ glance image-create --name <name> --container-format <format> --disk-format <format> --file <your.image.filename>
+    $ glance image-create --name <name> --container-format <format> --disk-format <format> --file <your.image.filename>
 
-    Example:
+Example:
 
-    .. code-block:: text
+.. code-block:: text
 
-        $ glance image-create --name bigip11.6.0 --container-format bare --disk-format qcow2 --file BIGIP-11.6.0.6.146.442.LTM.Small.qcow2
+    $ glance image-create --name bigip11.6.0 --container-format bare --disk-format qcow2 --file BIGIP-11.6.0.6.146.442.LTM.Small.qcow2
 
-**CAUTION:** Do not import a qcow2 zip file; the format isn’t compatible with OpenStack.
+
+.. caution::
+
+    Do not import a qcow2 zip file; the format isn’t compatible with OpenStack.

--- a/docs/guides/includes/os_ve_assign-floating-ip.rst
+++ b/docs/guides/includes/os_ve_assign-floating-ip.rst
@@ -6,10 +6,13 @@ To assign a floating IP using the Horizon dashboard:
 
 1. Go to :menuselection:`Project --> Compute --> Instances`, then choose :guilabel:`Associate Floating IP` from the drop-down menu in the :menuselection:`Actions` column.
 
-2. Select a :guilabel:`Floating IP` from the :guilabel:`IP Address` drop-down menu\*.
+2. Select a :guilabel:`Floating IP` from the :guilabel:`IP Address` drop-down menu.
 
-3. In the :guilabel:`port` drop-down, select the port for your BIG-IP image that corresponds to ``bigip_external``.
+3. In the :guilabel:`port` drop-down, select the port for your BIG-IP image that corresponds to the external VLAN you set up for your BIG-IP.
 
 4. Click :guilabel:`Associate`.
 
-\* If no floating IP addresses are available, click ``+`` to generate one, then click :guilabel:`Allocate`.
+.. tip::
+
+    If no floating IP addresses are available, click ``+`` to generate one, then click :guilabel:`Allocate`.
+

--- a/docs/guides/includes/os_ve_base_networking-external.rst
+++ b/docs/guides/includes/os_ve_base_networking-external.rst
@@ -1,78 +1,21 @@
 .. _os_ve_base_networking-external:
 
-1. Create the external (physical) network.
 
-    .. code-block:: text
+.. note::
 
-        # neutron net-create <network_name>
-
-
-    Example:
-
-    .. code-block:: text
-
-        # neutron net-create bigip_external
-        Created a new network:
-        +---------------------------+--------------------------------------+
-        | Field                     | Value                                |
-        +---------------------------+--------------------------------------+
-        | admin_state_up            | True                                 |
-        | id                        | 05f61e74-37e0-4c30-a664-762dfef1a221 |
-        | mtu                       | 0                                    |
-        | name                      | bigip_external                       |
-        | provider:network_type     | vxlan                                |
-        | provider:physical_network |                                      |
-        | provider:segmentation_id  | 84                                   |
-        | router:external           | False                                |
-        | shared                    | False                                |
-        | status                    | ACTIVE                               |
-        | subnets                   |                                      |
-        | tenant_id                 | 1a35d6558b59423e83f4500f1ebc1cec     |
-        +---------------------------+--------------------------------------+
+    You should have already created the external (physical) network when setting up your OpenStack environment.
 
 
-2. Create the external subnet.
+1. Create an external subnet.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # neutron subnet-create --name <subnet_name> <external_network> <CIDR>
+    # neutron subnet-create --name <subnet_name> <external_network> <CIDR>
 
-    Example:
+2. Attach the subnet to the router.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # neutron subnet-create --name bigip_external_subnet bigip_external 10.20.0.0/24
-        Created a new subnet:
-        +-------------------+----------------------------------------------+
-        | Field             | Value                                        |
-        +-------------------+----------------------------------------------+
-        | allocation_pools  | {"start": "10.20.0.2", "end": "10.20.0.254"} |
-        | cidr              | 10.20.0.0/24                                 |
-        | dns_nameservers   |                                              |
-        | enable_dhcp       | True                                         |
-        | gateway_ip        | 10.20.0.1                                    |
-        | host_routes       |                                              |
-        | id                | ac966870-2165-4576-9f70-dcf4193e7c39         |
-        | ip_version        | 4                                            |
-        | ipv6_address_mode |                                              |
-        | ipv6_ra_mode      |                                              |
-        | name              | bigip_external_subnet                        |
-        | network_id        | 05f61e74-37e0-4c30-a664-762dfef1a221         |
-        | subnetpool_id     |                                              |
-        | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec             |
-        +-------------------+----------------------------------------------+
+    # neutron router-interface-add <router_name> <subnet_name>
 
-
-3. Attach the subnet to the router.
-
-    .. code-block:: text
-
-        #neutron router-interface-add <router_name> <subnet_name>
-
-    Example:
-
-    .. code-block:: text
-
-        # neutron router-interface-add router1 bigip_external_subnet
-        Added interface 2593c3be-fbc5-453c-901f-1d1d33b09951 to router router1.
 

--- a/docs/guides/includes/os_ve_base_networking-internal.rst
+++ b/docs/guides/includes/os_ve_base_networking-internal.rst
@@ -2,73 +2,19 @@
 
 1. Create an internal (private) network.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # neutron net-create <network_name>
-
-    Example:
-
-    .. code-block:: text
-
-        # neutron net-create bigip_internal
-        Created a new network:
-        +---------------------------+--------------------------------------+
-        | Field                     | Value                                |
-        +---------------------------+--------------------------------------+
-        | admin_state_up            | True                                 |
-        | id                        | e707fe41-3a36-4e15-b521-53496e36e2e0 |
-        | mtu                       | 0                                    |
-        | name                      | bigip_internal                       |
-        | provider:network_type     | vxlan                                |
-        | provider:physical_network |                                      |
-        | provider:segmentation_id  | 63                                   |
-        | router:external           | False                                |
-        | shared                    | False                                |
-        | status                    | ACTIVE                               |
-        | subnets                   |                                      |
-        | tenant_id                 | 1a35d6558b59423e83f4500f1ebc1cec     |
-        +---------------------------+--------------------------------------+
+    # neutron net-create <network_name>
 
 2. Create a private subnet.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # neutron subnet-create --name <subnet_name> <network_name> <CIDR>
-
-    Example:
-
-    .. code-block:: text
-
-        # neutron subnet-create --name bigip_internal_subnet bigip_internal 10.30.0.0/24
-        Created a new subnet:
-        +-------------------+----------------------------------------------+
-        | Field             | Value                                        |
-        +-------------------+----------------------------------------------+
-        | allocation_pools  | {"start": "10.30.0.2", "end": "10.30.0.254"} |
-        | cidr              | 10.30.0.0/24                                 |
-        | dns_nameservers   |                                              |
-        | enable_dhcp       | True                                         |
-        | gateway_ip        | 10.30.0.1                                    |
-        | host_routes       |                                              |
-        | id                | f4a01d74-730e-428a-8722-f2fe94346f87         |
-        | ip_version        | 4                                            |
-        | ipv6_address_mode |                                              |
-        | ipv6_ra_mode      |                                              |
-        | name              | bigip_internal_subnet                        |
-        | network_id        | e707fe41-3a36-4e15-b521-53496e36e2e0         |
-        | subnetpool_id     |                                              |
-        | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec             |
-        +-------------------+----------------------------------------------+
+    # neutron subnet-create --name <subnet_name> <network_name> <CIDR>
 
 3. Attach the subnet to the router.
 
-    .. code-block:: text
+.. code-block:: text
 
-        #neutron router-interface-add <router_name> <subnet_name>
+    #neutron router-interface-add <router_name> <subnet_name>
 
-    Example:
-
-    .. code-block:: text
-
-        # neutron router-interface-add router1 bigip_internal_subnet
-        Added interface 20a6a00c-6708-4f73-a94f-76d86d518c4c to router router1.

--- a/docs/guides/includes/os_ve_deploy_big-ip_next-steps.rst
+++ b/docs/guides/includes/os_ve_deploy_big-ip_next-steps.rst
@@ -1,16 +1,18 @@
 .. _os_ve_deploy_big-ip_next-steps:
 
-**TIP**: You can access the BIG-IP from the Horizon dashboard via :menuselection:`System --> Instances --> Console`.
+.. tip::
 
-On first launch, the console will display something similar to the following:
+    You can access the BIG-IP from the Horizon dashboard via :menuselection:`System --> Instances --> Console`.
 
-    .. code-block:: text
+    On first launch, the console will display something similar to the following:
 
-        BIG-IP 11.6.0 Build 0.0.401
-        Kernel 2.6.23-358.23.2.e16.f5.x86_64 on an x86_64
-            r: ZBYLYQIGZJ   a: MKYBLGHLTB
-        localhost login:
+        .. code-block:: text
 
-The 'r:' and 'a:' strings displayed are randomly-generated passwords for the root and admin accounts, respectively. **Make note of them when they're shown, because they will not be shown again**.
+            BIG-IP 11.6.0 Build 0.0.401
+            Kernel 2.6.23-358.23.2.e16.f5.x86_64 on an x86_64
+                r: ZBYLYQIGZJ   a: MKYBLGHLTB
+            localhost login:
+
+    The ``r:`` and ``a:`` strings displayed are randomly-generated passwords for the root and admin accounts, respectively. **Make note of them when they're shown, because they will not be shown again**.
 
 Now that your BIG-IP VE is running, you will need to configure it. See :ref:`Further Reading <further_reading>` for more information.

--- a/docs/guides/includes/os_ve_launch_instance.rst
+++ b/docs/guides/includes/os_ve_launch_instance.rst
@@ -8,20 +8,17 @@ To launch an instance using the OpenStack Horizon dashboard (easiest method):
 
    -  On the :guilabel:`Project & User` tab:
         - select :guilabel:`admin` for each.
-
    -  On the :guilabel:`Details` tab:
         - enter a descriptive instance name;
         - choose your custom flavor;
         - select :guilabel:`boot from image` as the boot source;
         - select your BIG-IP image.
-
    -  On the :guilabel:`Access & Security` tab:
         - select the :guilabel:`BIG-IP_default` security group.
-
    -  On the :guilabel:`Network` tab:
-        - select at least 2 networks\* (3 if you're using SR-IOV).
-
+        - select at least 2 networks (3 if you're using SR-IOV).
    -  Click :guilabel:`Launch`.
 
+.. warning::
 
-\* **Do not select the physical external network** when launching an instance.
+    Do not select the physical external network when launching an instance. Choose the VLANs you set up for use with your BIG-IP.

--- a/docs/guides/includes/ve_before-you-start.rst
+++ b/docs/guides/includes/ve_before-you-start.rst
@@ -1,10 +1,11 @@
 You must have the following before proceeding:
 
- 1. A functional OpenStack environment with at least one controller node, one compute node, and one network node. (Can be an :ref:`all-in-one <os_all-in-one_deployment>` deployment.)
+- A functional OpenStack environment with at least one controller node, one compute node, and one network node. (Can be an :ref:`all-in-one <os_all-in-one_deployment>` deployment.)
 
- 2. An OpenStack-compatible BIG-IP VE qcow2 image. (**NOTE:** This cannot be a qcow2 zip file.)
+- An OpenStack-compatible BIG-IP VE qcow2 image. (**NOTE:** This cannot be a qcow2 zip file.)
 
- 3. Basic understanding of OpenStack networking concepts. See the `OpenStack docs <http://docs.openstack.org/>`_ for your release for more information.
+- Basic understanding of OpenStack networking concepts. See the `OpenStack docs <http://docs.openstack.org/>`_ for your release for more information.
 
+.. important::
 
-**IMPORTANT:** You can be logged in as root or as an admin user to execute the commands presented in this guide. You'll need to source your admin credentials file (e.g., ``source keystonerc_admin``) to use the ``openstack``, ``nova``, and ``neutron`` commands.
+    You can be logged in as root or as an admin user to execute the commands presented in this guide. You'll need to source your admin credentials file (e.g., ``source keystonerc_admin``) to use the ``openstack``, ``nova``, and ``neutron`` commands.

--- a/docs/guides/os-config-guide.rst
+++ b/docs/guides/os-config-guide.rst
@@ -5,45 +5,35 @@ OpenStack Configuration Guide
 
 Overview
 --------
-
 This guide will allow a user who already has an all-in-one OpenStack |openstack| deployment to configure it to attach to an existing external network.
 
-The instructions presented here were prepared from a Packstack deployment on OpenStack |openstack| using CentOS 7. We relied heavily on the
-RDO project's `Neutron with existing external network <https://www.rdoproject.org/networking/neutron-with-existing-external-network/>`_ and the Red Hat Enterprise Linux 7 `OpenStack Networking Guide <https://access.redhat.com/documentation/en/red-hat-enterprise-linux-openstack-platform/7/networking-guide/networking-guide>`_. We've found both documentation sets extremely helpful and recommend consulting them for any issues you may encounter.
+The instructions presented here were prepared from a Packstack deployment on OpenStack |openstack| using CentOS 7. We relied heavily on the RDO project's `Neutron with existing external network <https://www.rdoproject.org/networking/neutron-with-existing-external-network/>`_ and the Red Hat Enterprise Linux 7 `OpenStack Networking Guide <https://access.redhat.com/documentation/en/red-hat-enterprise-linux-openstack-platform/7/networking-guide/networking-guide>`_. We've found both documentation sets extremely helpful and recommend consulting them for any issues you may encounter.
 
 Users
 `````
 
-When installing CentOS, we created a root user and a user with administrative priveleges. Our root user has the password 'default'; our
-admin user is 'manager', with the password 'manager'. In all command blocks shown in this guide, the assumed user is represented by the
-command prompt symbol:
+When installing CentOS, we created a root user and a user with administrative priveleges. Our root user has the password 'default'; our admin user is 'manager', with the password 'manager'. In all command blocks shown in this guide, the assumed user is represented by the command prompt symbol:
 
-    .. code-block:: text
+.. code-block:: text
 
-        # = root
-        $ = admin
+    # = root
+    $ = admin
 
-**WARNING: This guide describes how to deploy OpenStack Kilo. This is an open source project that is continually changing; while the instructions
-included here worked for us, there is no guarantee they will work exactly the same for you.**
+
+.. caution::
+
+    This guide describes how to configure an OpenStack |openstack| environment. Because this is an open source project that is continually changing, you may see some variations between the commands presented here and those available in your environment.
+
 
 Prerequisites
 `````````````
-
-OpenStack: All-in-one deployment on OpenStack |openstack|. See our :ref:`OpenStack deployment guide <os-deploy-guide>` for setup instructions.
-
-Software: Red Hat Enterprise Linux (RHEL) 7 is the minimum recommended
-version you can use with OpenStack Kilo. You can also use any of the
-equivalent versions of RHEL-based Linux distributions (CentOS,
-Scientific Linux, etc.). x86\_64 is currently the only supported
-architecture.
-
-Hardware: Machine with at least 4GB RAM, processors with hardware virtualization extensions, and at least one network adapter. For more
-information, see the OpenStack Install guides at http://docs.openstack.org.
+- OpenStack: All-in-one deployment on OpenStack |openstack|. See our :ref:`OpenStack deployment guide <os-deploy-guide>` for setup instructions.
+- Software: Red Hat Enterprise Linux (RHEL) 7 is the minimum recommended version you can use with OpenStack |openstack|. You can also use any of the equivalent versions of RHEL-based Linux distributions (CentOS, Scientific Linux, etc.). x86\_64 is currently the only supported architecture.
+- Hardware: Machine with at least 4GB RAM, processors with hardware virtualization extensions, and at least one network adapter. For more information, see the OpenStack Install guide for |openstack| at http://docs.openstack.org.
 
 Releases and Versioning
 ```````````````````````
-
-See :ref:`F5 OpenStack Releases and Support Matrix <releases-and-versioning>`.
+See the :ref:`F5 OpenStack Releases and Support Matrix <releases-and-versioning>`.
 
 
 Configure the Neutron Network
@@ -51,7 +41,6 @@ Configure the Neutron Network
 
 Before you Start
 ````````````````
-
 To configure Neutron to work with an existing external network, you'll need to identify the device that's attached to the management
 network and record a few key values:
 
@@ -61,78 +50,78 @@ network and record a few key values:
 -   GATEWAY
 -   DNS1
 
-To find these values, run `ip addr show` and/or `ifconfig`. In our example, the device connected to the management network is enp2s0; yours
-may be something simpler, such as eth0. The IP address is listed as 'inet'.
+To find these values, run ``ip addr show`` and/or ``ifconfig``. In our example, the device connected to the management network is enp2s0; yours may be something simpler, such as eth0. The IP address is listed as 'inet'.
 
-**NOTE**: Do not copy and paste the IP addresses shown in this document when setting up your environment. Use the valid IP address(es) for your
-machine(s).
+.. note::
 
-    .. code-block:: text
+    Do not copy and paste the IP addresses shown in this document when setting up your environment. Use the valid IP address(es) for your machine(s).
 
-        # ip addr show
-        1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
-            link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
-            inet 127.0.0.1/8 scope host lo
-               valid_lft forever preferred_lft forever
-            inet6 ::1/128 scope host
-               valid_lft forever preferred_lft forever
-        2: ens2f0: <BROADCAST,MULTICAST> mtu 1500 qdisc mq state DOWN qlen 1000
-            link/ether 78:e3:b5:0b:61:a4 brd ff:ff:ff:ff:ff:ff
-        3: ens2f1: <BROADCAST,MULTICAST> mtu 1500 qdisc mq state DOWN qlen 1000
-            link/ether 78:e3:b5:0b:61:a6 brd ff:ff:ff:ff:ff:ff
-        4: enp2s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
-            link/ether b4:99:ba:a9:55:f0 brd ff:ff:ff:ff:ff:ff
-            inet 10.190.4.193/21 brd 10.190.7.255 scope global dynamic enp2s0
-               valid_lft 19506sec preferred_lft 19506sec
-            inet6 fe80::b699:baff:fea9:55f0/64 scope link
-               valid_lft forever preferred_lft forever
-        5: eno1: <BROADCAST,MULTICAST> mtu 1500 qdisc pfifo_fast state DOWN qlen 1000
-            link/ether b4:99:ba:a9:55:f1 brd ff:ff:ff:ff:ff:ff
-        6: ovs-system: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN
-            link/ether 5e:31:76:30:05:cb brd ff:ff:ff:ff:ff:ff
-        7: br-ex: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN
-            link/ether 3a:c1:b2:f4:30:48 brd ff:ff:ff:ff:ff:ff
-            inet6 fe80::38c1:b2ff:fef4:3048/64 scope link
-               valid_lft forever preferred_lft forever
-        8: br-int: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN
-            link/ether 2e:99:9e:a2:cc:43 brd ff:ff:ff:ff:ff:ff
-        9: br-tun: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN
-            link/ether b2:91:a4:55:a0:4a brd ff:ff:ff:ff:ff:ff
+.. code-block:: text
 
-    .. code-block:: text
+    # ip addr show
+    1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
+        link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+        inet 127.0.0.1/8 scope host lo
+           valid_lft forever preferred_lft forever
+        inet6 ::1/128 scope host
+           valid_lft forever preferred_lft forever
+    2: ens2f0: <BROADCAST,MULTICAST> mtu 1500 qdisc mq state DOWN qlen 1000
+        link/ether 78:e3:b5:0b:61:a4 brd ff:ff:ff:ff:ff:ff
+    3: ens2f1: <BROADCAST,MULTICAST> mtu 1500 qdisc mq state DOWN qlen 1000
+        link/ether 78:e3:b5:0b:61:a6 brd ff:ff:ff:ff:ff:ff
+    4: enp2s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+        link/ether b4:99:ba:a9:55:f0 brd ff:ff:ff:ff:ff:ff
+        inet 10.190.4.193/21 brd 10.190.7.255 scope global dynamic enp2s0
+           valid_lft 19506sec preferred_lft 19506sec
+        inet6 fe80::b699:baff:fea9:55f0/64 scope link
+           valid_lft forever preferred_lft forever
+    5: eno1: <BROADCAST,MULTICAST> mtu 1500 qdisc pfifo_fast state DOWN qlen 1000
+        link/ether b4:99:ba:a9:55:f1 brd ff:ff:ff:ff:ff:ff
+    6: ovs-system: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN
+        link/ether 5e:31:76:30:05:cb brd ff:ff:ff:ff:ff:ff
+    7: br-ex: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN
+        link/ether 3a:c1:b2:f4:30:48 brd ff:ff:ff:ff:ff:ff
+        inet6 fe80::38c1:b2ff:fef4:3048/64 scope link
+           valid_lft forever preferred_lft forever
+    8: br-int: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN
+        link/ether 2e:99:9e:a2:cc:43 brd ff:ff:ff:ff:ff:ff
+    9: br-tun: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN
+        link/ether b2:91:a4:55:a0:4a brd ff:ff:ff:ff:ff:ff
 
-        # ifconfig
-        br-ex: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
-                inet6 fe80::38c1:b2ff:fef4:3048  prefixlen 64  scopeid 0x20<link>
-                ether 3a:c1:b2:f4:30:48  txqueuelen 0  (Ethernet)
-                RX packets 0  bytes 0 (0.0 B)
-                RX errors 0  dropped 0  overruns 0  frame 0
-                TX packets 8  bytes 648 (648.0 B)
-                TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+.. code-block:: text
 
-        enp2s0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
-                inet 10.190.4.193  netmask 255.255.248.0  broadcast 10.190.7.255
-                inet6 fe80::b699:baff:fea9:55f0 prefixlen 64  scopeid 0x20<link>
-                ether b4:99:ba:a9:55:f0  txqueuelen 1000  (Ethernet)
-                RX packets 1183741  bytes 541128626 (516.0 MiB)
-                RX errors 0  dropped 0  overruns 0  frame 0
-                TX packets 130388  bytes 13634811 (13.0 MiB)
-                TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
-                device interrupt 16  memory 0xf7ee0000-f7f00000
+    # ifconfig
+    br-ex: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+            inet6 fe80::38c1:b2ff:fef4:3048  prefixlen 64  scopeid 0x20<link>
+            ether 3a:c1:b2:f4:30:48  txqueuelen 0  (Ethernet)
+            RX packets 0  bytes 0 (0.0 B)
+            RX errors 0  dropped 0  overruns 0  frame 0
+            TX packets 8  bytes 648 (648.0 B)
+            TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
 
-        lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
-                inet 127.0.0.1  netmask 255.0.0.0
-                inet6 ::1  prefixlen 128  scopeid 0x10<host>
-                loop  txqueuelen 0  (Local Loopback)
-                RX packets 4013798  bytes 371688922 (354.4 MiB)
-                RX errors 0  dropped 0  overruns 0  frame 0
-                TX packets 4013798  bytes 371688922 (354.4 MiB)
-                TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+    enp2s0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+            inet 10.190.4.193  netmask 255.255.248.0  broadcast 10.190.7.255
+            inet6 fe80::b699:baff:fea9:55f0 prefixlen 64  scopeid 0x20<link>
+            ether b4:99:ba:a9:55:f0  txqueuelen 1000  (Ethernet)
+            RX packets 1183741  bytes 541128626 (516.0 MiB)
+            RX errors 0  dropped 0  overruns 0  frame 0
+            TX packets 130388  bytes 13634811 (13.0 MiB)
+            TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+            device interrupt 16  memory 0xf7ee0000-f7f00000
+
+    lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
+            inet 127.0.0.1  netmask 255.0.0.0
+            inet6 ::1  prefixlen 128  scopeid 0x10<host>
+            loop  txqueuelen 0  (Local Loopback)
+            RX packets 4013798  bytes 371688922 (354.4 MiB)
+            RX errors 0  dropped 0  overruns 0  frame 0
+            TX packets 4013798  bytes 371688922 (354.4 MiB)
+            TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
 
 Configure the bridge
 ````````````````````
-
- 1. Create/modify :file:`/etc/sysconfig/network-scripts/ifcfg-br-ex` and add the entries shown below, using the appropriate values for your network. This moves the IP address and netmask that were assigned to the device ``enp2s0`` to the bridge ``br-ex``.
+1. Create/modify :file:`/etc/sysconfig/network-scripts/ifcfg-br-ex` and add the entries shown below, using the appropriate values for your network. This moves the IP address and netmask that were assigned to the device ``enp2s0`` to the bridge ``br-ex``.
 
     .. code-block:: text
 
@@ -146,31 +135,32 @@ Configure the bridge
         GATEWAY=10.190.0.1 \\ you may need to get this information from your network admin if you don't know it
         DNS1=10.190.0.20 \\ you may need to get this information from your network admin if you don't know it
 
- 2. Edit the config file for the device -- :file:`/etc/sysconfig/network-scripts/ifcfg-enp2s0` -- and add the lines shown below, using the appropriate values your network. This attaches the devices to the OVS bridge as a port.
+2. Edit the config file for the device -- :file:`/etc/sysconfig/network-scripts/ifcfg-enp2s0` -- and add the lines shown below, using the appropriate values your network. This attaches the devices to the OVS bridge as a port.
 
-    **NOTE:** You will need to remove the ``BOOTPROTO`` entry from the top of this file if it exists.
+.. note::
 
-    .. code-block:: text
+    You will need to remove the ``BOOTPROTO`` entry from the top of this file if it exists.
 
-        # vi /etc/sysconfig/network-scripts/ifcfg-enp2s0
-        ...
-        DEVICE="enp2s0"
-        HWADDR="b4:99:ba:a9:55:f0" \\ shown in the ifconfig readout as 'ether'
-        TYPE="OVSPort"
-        DEVICETYPE="ovs"
-        OVS_BRIDGE="br-ex"
-        ONBOOT="yes"
+.. code-block:: text
 
- 3. Run the command below to assign a name to the br-ex OVS bridge ('exnet'). This shows up as the ``provider:physical_network`` entry for the external networks. **This entry must be present** in order for the `F5 OpenStack LBaaSv1 <http://f5-openstack-lbaasv1.readthedocs.org>`_ plugin to work.
+    # vi /etc/sysconfig/network-scripts/ifcfg-enp2s0
+    ...
+    DEVICE="enp2s0"
+    HWADDR="b4:99:ba:a9:55:f0" \\ shown in the ifconfig readout as 'ether'
+    TYPE="OVSPort"
+    DEVICETYPE="ovs"
+    OVS_BRIDGE="br-ex"
+    ONBOOT="yes"
 
-    .. code-block:: text
+3. Run the command below to assign a name to the br-ex OVS bridge ('exnet'). This shows up as the ``provider:physical_network`` entry for the external networks. **This entry must be present** in order for the `F5 OpenStack LBaaSv1 <http://f5-openstack-lbaasv1.readthedocs.org>`_ plugin to work.
 
-        # openstack-config --set /etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini ovs bridge_mappings extnet:br-ex
+.. code-block:: text
+
+    # openstack-config --set /etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini ovs bridge_mappings extnet:br-ex
 
 
 Configure network types
 ```````````````````````
-
 Run the command below to make the vxlan, flat, and vlan options available. (This is noted in the `RDO
 documentation <https://www.rdoproject.org/networking/neutron-with-existing-external-network/>`_ as a bug workaround.)
 
@@ -178,181 +168,186 @@ documentation <https://www.rdoproject.org/networking/neutron-with-existing-exter
 
         # openstack-config --set /etc/neutron/plugin.ini ml2 type_drivers vxlan,flat,vlan
 
+
+Set the DHCP Domain
+```````````````````
 If you're using DHCP to acquire IP addresses automatically, replace the default ``dhcp_domain`` in :file:`/etc/neutron/dhcp_agent.ini` with  your local domain. If you're using static IP address assignment, this step shouldn't be necessary.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # vi /etc/neutron/dhcp_agent.ini
-        ...
-        # Domain to use for building the hostnames
-        # dhcp_domain = openstacklocal
-        dhcp_domain = [something.example.com]
-        ...
+    # vi /etc/neutron/dhcp_agent.ini
+    ...
+    # Domain to use for building the hostnames
+    # dhcp_domain = openstacklocal
+    dhcp_domain = [something.example.com]
+    ...
 
 
 Reboot your machine
 ```````````````````
+.. note::
 
-**NOTE:** This will terminate your connection.
+    This will terminate your connection.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # reboot
+    # reboot
 
 
 Set up the router gateway for the external network
 ``````````````````````````````````````````````````
+.. note::
 
-**NOTE:** The steps in the following sections use ``neutron`` commands. You'll need to run ``source keystonerc_admin`` before proceeding to ensure access to the ``neutron`` command line tools.
+    The steps in the following sections use ``neutron`` commands. You'll need to run ``source keystonerc_admin`` before proceeding to ensure access to the ``neutron`` command line tools.
 
-You can also configure the network using the Horizon dashboard. See the `OpenStack dashboard user guide <http://docs.openstack.org/user-guide/dashboard.html>`_ for more information.
-
+    You can also configure the network using the Horizon dashboard. See the `OpenStack dashboard user guide <http://docs.openstack.org/user-guide/dashboard.html>`_ for more information.
 
 Create an external network
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code-block:: text
 
-    .. code-block:: text
-
-        # neutron net-create external_network --provider:network_type flat --provider:physical_network extnet  --router:external --shared
-        Created a new network:
-        +---------------------------+--------------------------------------+
-        | Field                     | Value                                |
-        +---------------------------+--------------------------------------+
-        | admin_state_up            | True                                 |
-        | id                        | 8fe1a243-4970-4c5a-84c0-6fef5612c844 |
-        | mtu                       | 0                                    |
-        | name                      | external_network                     |
-        | provider:network_type     | flat                                 |
-        | provider:physical_network | extnet                               |
-        | provider:segmentation_id  |                                      |
-        | router:external           | True                                 |
-        | shared                    | True                                 |
-        | status                    | ACTIVE                               |
-        | subnets                   |                                      |
-        | tenant_id                 | 1a35d6558b59423e83f4500f1ebc1cec     |
-        +---------------------------+--------------------------------------+
+    # neutron net-create external_network --provider:network_type flat --provider:physical_network extnet  --router:external --shared
+    Created a new network:
+    +---------------------------+--------------------------------------+
+    | Field                     | Value                                |
+    +---------------------------+--------------------------------------+
+    | admin_state_up            | True                                 |
+    | id                        | 8fe1a243-4970-4c5a-84c0-6fef5612c844 |
+    | mtu                       | 0                                    |
+    | name                      | external_network                     |
+    | provider:network_type     | flat                                 |
+    | provider:physical_network | extnet                               |
+    | provider:segmentation_id  |                                      |
+    | router:external           | True                                 |
+    | shared                    | True                                 |
+    | status                    | ACTIVE                               |
+    | subnets                   |                                      |
+    | tenant_id                 | 1a35d6558b59423e83f4500f1ebc1cec     |
+    +---------------------------+--------------------------------------+
 
 
 Create a public subnet
 ~~~~~~~~~~~~~~~~~~~~~~
-
 This will allow you to assign floating IP addresses to your tenants.
 
-    **NOTE:** Be sure the subnet range is outside the external DHCP range if you're using DHCP.
+.. note::
 
-    .. code-block:: text
+    Be sure the subnet range is outside the external DHCP range if you're using DHCP.
 
-        # neutron subnet-create --name public_subnet --enable_dhcp=False --allocation-pool=start=10.190.6.250,end=10.190.6.254 --gateway=10.190.0.1 external_network 10.190.0.0/21
-        Created a new subnet:
-        +-------------------+--------------------------------------------------+
-        | Field             | Value                                            |
-        +-------------------+--------------------------------------------------+
-        | allocation_pools  | {"start": "10.190.6.250", "end": "10.190.6.254"} |
-        | cidr              | 10.190.0.0/21                                    |
-        | dns_nameservers   |                                                  |
-        | enable_dhcp       | False                                            |
-        | gateway_ip        | 10.190.0.1                                       |
-        | host_routes       |                                                  |
-        | id                | 91baa5e9-c061-4d29-9584-c171c0c25686             |
-        | ip_version        | 4                                                |
-        | ipv6_address_mode |                                                  |
-        | ipv6_ra_mode      |                                                  |
-        | name              | public_subnet                                    |
-        | network_id        | fe6b0a53-8d80-4607-96f6-89e31af0b6e6             |
-        | subnetpool_id     |                                                  |
-        | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec                 |
-        +-------------------+--------------------------------------------------+
+.. code-block:: text
+
+    # neutron subnet-create --name public_subnet --enable_dhcp=False --allocation-pool=start=10.190.6.250,end=10.190.6.254 --gateway=10.190.0.1 external_network 10.190.0.0/21
+    Created a new subnet:
+    +-------------------+--------------------------------------------------+
+    | Field             | Value                                            |
+    +-------------------+--------------------------------------------------+
+    | allocation_pools  | {"start": "10.190.6.250", "end": "10.190.6.254"} |
+    | cidr              | 10.190.0.0/21                                    |
+    | dns_nameservers   |                                                  |
+    | enable_dhcp       | False                                            |
+    | gateway_ip        | 10.190.0.1                                       |
+    | host_routes       |                                                  |
+    | id                | 91baa5e9-c061-4d29-9584-c171c0c25686             |
+    | ip_version        | 4                                                |
+    | ipv6_address_mode |                                                  |
+    | ipv6_ra_mode      |                                                  |
+    | name              | public_subnet                                    |
+    | network_id        | fe6b0a53-8d80-4607-96f6-89e31af0b6e6             |
+    | subnetpool_id     |                                                  |
+    | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec                 |
+    +-------------------+--------------------------------------------------+
+
 
 Create a router
 ~~~~~~~~~~~~~~~
+.. code-block:: text
 
-    .. code-block:: text
+    # neutron router-create router1
+    Created a new router:
+    +-----------------------+--------------------------------------+
+    | Field                 | Value                                |
+    +-----------------------+--------------------------------------+
+    | admin_state_up        | True                                 |
+    | distributed           | False                                |
+    | external_gateway_info |                                      |
+    | ha                    | False                                |
+    | id                    | 9625ca6a-694b-404c-bdc3-787a92664e00 |
+    | name                  | router1                              |
+    | routes                |                                      |
+    | status                | ACTIVE                               |
+    | tenant_id             | 1a35d6558b59423e83f4500f1ebc1cec     |
+    +-----------------------+--------------------------------------+
 
-        # neutron router-create router1
-        Created a new router:
-        +-----------------------+--------------------------------------+
-        | Field                 | Value                                |
-        +-----------------------+--------------------------------------+
-        | admin_state_up        | True                                 |
-        | distributed           | False                                |
-        | external_gateway_info |                                      |
-        | ha                    | False                                |
-        | id                    | 9625ca6a-694b-404c-bdc3-787a92664e00 |
-        | name                  | router1                              |
-        | routes                |                                      |
-        | status                | ACTIVE                               |
-        | tenant_id             | 1a35d6558b59423e83f4500f1ebc1cec     |
-        +-----------------------+--------------------------------------+
 
 Attach the router to the gateway
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code-block:: text
 
-    .. code-block:: text
-
-        # neutron router-gateway-set router1 external_network
-        Set gateway for router router1
+    # neutron router-gateway-set router1 external_network
+    Set gateway for router router1
 
 
 Create a private network and subnet
 ```````````````````````````````````
-
 A private network and subnet allow you to allocate private resources in your cloud to various projects/users.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # neutron net-create private_network
-        Created a new network:
-        +---------------------------+--------------------------------------+
-        | Field                     | Value                                |
-        +---------------------------+--------------------------------------+
-        | admin_state_up            | True                                 |
-        | id                        | 222840d7-4f9f-411d-a7de-6343ce71fee9 |
-        | mtu                       | 0                                    |
-        | name                      | private_network                      |
-        | provider:network_type     | vxlan                                |
-        | provider:physical_network |                                      |
-        | provider:segmentation_id  | 77                                   |
-        | router:external           | False                                |
-        | shared                    | False                                |
-        | status                    | ACTIVE                               |
-        | subnets                   |                                      |
-        | tenant_id                 | 1a35d6558b59423e83f4500f1ebc1cec     |
-        +---------------------------+--------------------------------------+
+    # neutron net-create private_network
+    Created a new network:
+    +---------------------------+--------------------------------------+
+    | Field                     | Value                                |
+    +---------------------------+--------------------------------------+
+    | admin_state_up            | True                                 |
+    | id                        | 222840d7-4f9f-411d-a7de-6343ce71fee9 |
+    | mtu                       | 0                                    |
+    | name                      | private_network                      |
+    | provider:network_type     | vxlan                                |
+    | provider:physical_network |                                      |
+    | provider:segmentation_id  | 77                                   |
+    | router:external           | False                                |
+    | shared                    | False                                |
+    | status                    | ACTIVE                               |
+    | subnets                   |                                      |
+    | tenant_id                 | 1a35d6558b59423e83f4500f1ebc1cec     |
+    +---------------------------+--------------------------------------+
 
-    .. code-block:: text
+.. code-block:: text
 
-        # neutron subnet-create --name private_subnet private_network 172.16.0.0/12 --dns-nameserver=10.190.0.20
-        Created a new subnet:
-        +-------------------+-------------------------------------------------+
-        | Field             | Value                                           |
-        +-------------------+-------------------------------------------------+
-        | allocation_pools  | {"start": "172.16.0.255", "end": "172.16.16.0"} |
-        |                   | {"start": "172.16.0.2", "end": "172.16.0.254"}  |
-        | cidr              | 172.16.0.0/12                                   |
-        | dns_nameservers   | 10.190.0.20                                     |
-        | enable_dhcp       | True                                            |
-        | gateway_ip        | 172.16.0.1                                      |
-        | host_routes       |                                                 |
-        | id                | 5528fd9e-76dc-427e-9791-2cad6c87ba06            |
-        | ip_version        | 4                                               |
-        | ipv6_address_mode |                                                 |
-        | ipv6_ra_mode      |                                                 |
-        | name              | private_subnet                                  |
-        | network_id        | 99717ae6-5cfb-45fb-b846-f8e99599cd35            |
-        | subnetpool_id     |                                                 |
-        | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec                |
-        +-------------------+-------------------------------------------------+
+    # neutron subnet-create --name private_subnet private_network 172.16.0.0/12 --dns-nameserver=10.190.0.20
+    Created a new subnet:
+    +-------------------+-------------------------------------------------+
+    | Field             | Value                                           |
+    +-------------------+-------------------------------------------------+
+    | allocation_pools  | {"start": "172.16.0.255", "end": "172.16.16.0"} |
+    |                   | {"start": "172.16.0.2", "end": "172.16.0.254"}  |
+    | cidr              | 172.16.0.0/12                                   |
+    | dns_nameservers   | 10.190.0.20                                     |
+    | enable_dhcp       | True                                            |
+    | gateway_ip        | 172.16.0.1                                      |
+    | host_routes       |                                                 |
+    | id                | 5528fd9e-76dc-427e-9791-2cad6c87ba06            |
+    | ip_version        | 4                                               |
+    | ipv6_address_mode |                                                 |
+    | ipv6_ra_mode      |                                                 |
+    | name              | private_subnet                                  |
+    | network_id        | 99717ae6-5cfb-45fb-b846-f8e99599cd35            |
+    | subnetpool_id     |                                                 |
+    | tenant_id         | 1a35d6558b59423e83f4500f1ebc1cec                |
+    +-------------------+-------------------------------------------------+
+
 
 Connect the private network to the public network
 `````````````````````````````````````````````````
+.. code-block:: text
 
-    .. code-block:: text
+    # neutron router-interface-add router1 private_subnet
+    Added interface c0173575-d3dc-4018-939c-4481f0a1c152 to router router1.
 
-        # neutron router-interface-add router1 private_subnet
-        Added interface c0173575-d3dc-4018-939c-4481f0a1c152 to router router1.
+.. tip::
 
-**TIP:** To check what networks are configured, run ``openstack network list``. To view details for a configured network, run
-``openstack network show``.
+    To check what networks are configured, run ``openstack network list``. To view details for a configured network, run
+    ``openstack network show``.
 
     .. code-block:: text
 
@@ -382,112 +377,111 @@ Connect the private network to the public network
         | subnets                   | 49e2802a-ed2d-4eb8-a43d-2dac053433f5 |
         +---------------------------+--------------------------------------+
 
+
 Create the Data Network
-~~~~~~~~~~~~~~~~~~~~~~~
+```````````````````````
 
 Flat Provider Network
-`````````````````````
-
-    .. include:: includes/os_ve_deploy_flat-provider-network.rst
-
+~~~~~~~~~~~~~~~~~~~~~
+.. include:: includes/os_ve_deploy_flat-provider-network.rst
 
 VLAN provider network
-`````````````````````
-
-    .. include:: includes/os_ve_deploy_vlan-provider-network.rst
-
+~~~~~~~~~~~~~~~~~~~~~
+.. include:: includes/os_ve_deploy_vlan-provider-network.rst
 
 Add Projects and Users
 ----------------------
+Now that your network is configured, you'll probably want to create projects and users.
 
-Now that your network is configured, you'll probably want to create
-projects and users.
+.. note::
 
-**NOTES:**
- - According to the `OpenStack documentation <http://docs.openstack.org/openstack-ops/content/projects_users.html>`_: "In OpenStack user interfaces and documentation, a group of users is referred to as a project or tenant. These terms are interchangeable."
+    - According to the `OpenStack documentation <http://docs.openstack.org/openstack-ops/content/projects_users.html>`_: "In OpenStack user interfaces and documentation, a group of users is referred to as a project or tenant. These terms are interchangeable."
 
- - You do not need to be logged in as root to run the below commands. You do need to source :file:`keystonerc_admin`, though.
+    - You do not need to be logged in as root to run the below commands. You do need to source :file:`keystonerc_admin`, though.
 
 Add a Project
 `````````````
+The below command creates a project (or tenant) named 'demo1'.
 
-The below command creates a project (or tenant) named 'demo1'. It's enabled by default.
+.. code-block:: text
 
-    .. code-block:: text
+    $ openstack project create --description "My demo Project" demo1
+    +-------------+----------------------------------+
+    | Field       | Value                            |
+    +-------------+----------------------------------+
+    | description | My demo Project                  |
+    | enabled     | True                             |
+    | id          | fb76f73484554d3593964f24ec57bd05 |
+    | name        | demo1                            |
+    +-------------+----------------------------------+
 
-        $ openstack project create --description "My demo Project" demo1
-        +-------------+----------------------------------+
-        | Field       | Value                            |
-        +-------------+----------------------------------+
-        | description | My demo Project                  |
-        | enabled     | True                             |
-        | id          | fb76f73484554d3593964f24ec57bd05 |
-        | name        | demo1                            |
-        +-------------+----------------------------------+
 
 Add a User
 ``````````
+The below command creates a user named demo with access to the 'demo1' project.
 
-The below command creates a user named demo with access to the 'demo1' project. The new user account will be enabled by default.
+.. code-block:: text
 
-    .. code-block:: text
+    $ openstack user create --project demo1 --password foobar1 --email demo123@f5.com demo
+    +------------+----------------------------------+
+    | Field      | Value                            |
+    +------------+----------------------------------+
+    | email      | demo123@f5.com                   |
+    | enabled    | True                             |
+    | id         | c845db0c788443b4962b0717738ab0ce |
+    | name       | demo                             |
+    | project_id | fb76f73484554d3593964f24ec57bd05 |
+    | username   | demo                             |
+    +------------+----------------------------------+
 
-        $ openstack user create --project demo1 --password foobar1 --email demo123@f5.com demo
-        +------------+----------------------------------+
-        | Field      | Value                            |
-        +------------+----------------------------------+
-        | email      | demo123@f5.com                   |
-        | enabled    | True                             |
-        | id         | c845db0c788443b4962b0717738ab0ce |
-        | name       | demo                             |
-        | project_id | fb76f73484554d3593964f24ec57bd05 |
-        | username   | demo                             |
-        +------------+----------------------------------+
 
-**TIP:** Run ``openstack project list`` to view a list of configured projects and ``openstack user list`` to view a list of configured users.
+.. tip::
+
+    Run ``openstack project list`` to view a list of configured projects and ``openstack user list`` to view a list of configured users.
+
 
 Install an Image from Glance
 ----------------------------
-
 OpenStack's `Glance <http://docs.openstack.org/developer/glance/>`_ project is a service for sharing data assets to be used with other
 OpenStack services, including VM images.
 
 To get a `CirrOS image <http://docs.openstack.org/image-guide/obtain-images.html#cirros-test-images>`_ (not provisioned, without demo provisioning), run the command shown below.
 
-**NOTE:** Issues have been reported when using the ``--is-public=true`` flag. You may need to remove this, or change it to ``--visibility=public`` for the command to work.
+.. note::
 
-    .. code-block:: text
+    Issues have been reported when using the ``--is-public=true`` flag. You may need to remove this, or change it to ``--visibility=public`` for the command to work.
 
-        $ curl http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img | glance image-create --name='cirros_image' --is-public=true  --container-format=bare --disk-format=qcow2
-          % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                         Dload  Upload   Total   Spent    Left  Speed
-        100 12.6M  100 12.6M    0     0  1441k      0  0:00:09  0:00:09 --:--:-- 2050k
-        +------------------+--------------------------------------+
-        | Property         | Value                                |
-        +------------------+--------------------------------------+
-        | checksum         | ee1eca47dc88f4879d8a229cc70a07c6     |
-        | container_format | bare                                 |
-        | created_at       | 2016-01-21T23:39:08.000000           |
-        | deleted          | False                                |
-        | deleted_at       | None                                 |
-        | disk_format      | qcow2                                |
-        | id               | 5002704e-04c4-48d0-847f-23685cf748f5 |
-        | is_public        | True                                 |
-        | min_disk         | 0                                    |
-        | min_ram          | 0                                    |
-        | name             | cirros_image                         |
-        | owner            | 1a35d6558b59423e83f4500f1ebc1cec     |
-        | protected        | False                                |
-        | size             | 13287936                             |
-        | status           | active                               |
-        | updated_at       | 2016-01-21T23:39:17.000000           |
-        | virtual_size     | None                                 |
-        +------------------+--------------------------------------+
+.. code-block:: text
+
+    $ curl http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img | glance image-create --name='cirros_image' --is-public=true  --container-format=bare --disk-format=qcow2
+      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                     Dload  Upload   Total   Spent    Left  Speed
+    100 12.6M  100 12.6M    0     0  1441k      0  0:00:09  0:00:09 --:--:-- 2050k
+    +------------------+--------------------------------------+
+    | Property         | Value                                |
+    +------------------+--------------------------------------+
+    | checksum         | ee1eca47dc88f4879d8a229cc70a07c6     |
+    | container_format | bare                                 |
+    | created_at       | 2016-01-21T23:39:08.000000           |
+    | deleted          | False                                |
+    | deleted_at       | None                                 |
+    | disk_format      | qcow2                                |
+    | id               | 5002704e-04c4-48d0-847f-23685cf748f5 |
+    | is_public        | True                                 |
+    | min_disk         | 0                                    |
+    | min_ram          | 0                                    |
+    | name             | cirros_image                         |
+    | owner            | 1a35d6558b59423e83f4500f1ebc1cec     |
+    | protected        | False                                |
+    | size             | 13287936                             |
+    | status           | active                               |
+    | updated_at       | 2016-01-21T23:39:17.000000           |
+    | virtual_size     | None                                 |
+    +------------------+--------------------------------------+
 
 
 Launch an Instance
 ------------------
-
 We highly recommend that you follow the RDO `Running an Instance guide <https://www.rdoproject.org/install/running-an-instance/>`_ from
 here on out. They've done a great job describing the information, so we're not going to paraphrase it here.
 
@@ -499,16 +493,16 @@ We do have a few tips, though:
 
 - If your private network doesn't show up in the network list when adding an instance, it may be misconfigured.
 
+
 Further Reading
 ---------------
-
 Once you have successfully launched an instance in your OpenStack cloud, you may find the following doc sets helpful.
 
  - `OpenStack Admin User Guide <http://docs.openstack.org/user-guide-admin/>`_
  - `OpenStack Operations Guide <http://docs.openstack.org/ops/>`_
  - `F5 OpenStack LBaaSv1 Plugin Documentation <http://f5-openstack-lbaasv1.readthedocs.org/en/>`_
- - `F5 BIG-IP LTM kbase <https://support.f5.com/kb/en-us/products/big-ip_ltm.html>`_
- - F5 OpenStack and BIG-IP VE Documentation (coming soon!)
+ - `F5 BIG-IP LTM knowledge base <https://support.f5.com/kb/en-us/products/big-ip_ltm.html>`_
+ - :ref:`Deploying BIG-IP VE in OpenStack <deploy_big-ip_openstack>`
 
 
 

--- a/docs/guides/os-deploy-guide.rst
+++ b/docs/guides/os-deploy-guide.rst
@@ -15,9 +15,9 @@ This guide describes how to deploy OpenStack using Packstack. Both are open sour
 
 Prerequisites
 `````````````
-Hardware: Machine with at least 4GB RAM, processors with hardware virtualization extensions, and at least one network adapter. For more information, see the OpenStack installation guide for |openstack|.
+- Hardware: Machine with at least 4GB RAM, processors with hardware virtualization extensions, and at least one network adapter. For more information, see the OpenStack installation guide for |openstack|.
 
-Software: Red Hat Enterprise Linux (RHEL) 7 is the minimum recommended version you can use with OpenStack |openstack|. You can also use any of the equivalent versions of RHEL-based Linux distributions (CentOS, Scientific Linux, etc.). x86\_64 is currently the only supported architecture.
+- Software: Red Hat Enterprise Linux (RHEL) 7 is the minimum recommended version you can use with OpenStack |openstack|. You can also use any of the equivalent versions of RHEL-based Linux distributions (CentOS, Scientific Linux, etc.). x86\_64 is currently the only supported architecture.
 
 Releases and Versioning
 ```````````````````````
@@ -78,25 +78,29 @@ If Network Manager is running, run the following commands to disable it.
 Install Software Repositories
 `````````````````````````````
 
-**NOTE:** You can run these commands as root or manager. If you're logged in as manager (the admin user), you will need to use ``sudo``.
+.. note::
 
- 1. Update your current software packages:
+    You can run these commands as root or manager. If you're logged in as manager (the admin user), you will need to use ``sudo``.
+
+1. Update your current software packages:
 
     .. code-block:: text
 
         # yum install update -y
 
 
- 2. Install the software package for the OpenStack release of your choice. If you want to use the latest release, run:
+2. Install the software package for the OpenStack release of your choice. If you want to use the latest release, run:
 
     .. code-block:: text
 
         # yum install -y https://www.rdoproject.org/repos/rdo-release.rpm
 
 
-     **NOTE:** To install a different OpenStack release, see http://rdoproject.org/repos/ for the full listing.
+    .. note::
 
- 4. Install the software package for Packstack.
+        To install a different OpenStack release, see http://rdoproject.org/repos/ for the full listing.
+
+3. Install the software package for Packstack.
 
     .. code-block:: text
 
@@ -110,15 +114,20 @@ Deploy OpenStack using Packstack
 
 The quickest and easiest way to deploy OpenStack is via Packstack's ``--allinone`` option. This sets up a single machine as the controller, compute, and network node. Be aware that this configuration, while fairly simple to execute, is fairly limited. By default, the all-in-one configuration doesn't have `Heat <https://wiki.openstack.org/wiki/Heat>`_ and `Neutron LBaaS <https://wiki.openstack.org/wiki/Neutron/LBaaS>`_ enabled. For this reason, **we don't recommend** going with the default ``--allinone`` deployment. Instead, you can customize your all-in-one deployment with an answers file.
 
+.. _answers_file:
+
 Custom Configuration with an Answers File
 `````````````````````````````````````````
 Instead of using the ``--allinone`` flag, we generated an answers file -- :download:`f5-answers.txt` -- and edited it to enable the services we want and disable some options we don't want.
 
 .. note::
-The configurations in our answers file are basically equivalent to running the following command:
-.. code-block:: shell
 
-    $ packstack --os-heat-install=y --os-debug-mode=y --os-neutron-lbaas-install=y --provision-demo=n
+    The configurations in our answers file are basically equivalent to running the following command:
+
+    .. code-block:: shell
+
+        $ packstack --os-heat-install=y --os-debug-mode=y --os-neutron-lbaas-install=y --provision-demo=n
+
 
 To generate an answers file (replace ``[answers-file]`` with the file name of your choice):
 
@@ -161,27 +170,27 @@ For our custom all-in-one installation, we changed the following entries in the 
 
 .. note::
 
-When you generate an answers file, Packstack automatically includes the IP address of the machine on which the file is generated in
-the ``CONTROLLER_HOST``, ``COMPUTE_HOSTS``, & ``NETWORK_HOSTS`` entries. If you're using additional compute and/or network nodes, you'll need to edit the answers file to add in the IP addresses for those machines. As shown in the example below, multiple values should be comma-separated, without a space in between.
+    When you generate an answers file, Packstack automatically includes the IP address of the machine on which the file is generated in
+    the ``CONTROLLER_HOST``, ``COMPUTE_HOSTS``, & ``NETWORK_HOSTS`` entries. If you're using additional compute and/or network nodes, you'll need to edit the answers file to add in the IP addresses for those machines. As shown in the example below, multiple values should be comma-separated, without a space in between.
 
-.. code-block:: text
+    .. code-block:: text
 
-    # vi [answers-file].txt
-    ...
-    # IP address of the server on which to install OpenStack services
-    # specific to the controller role (for example, API servers or
-    # dashboard).
-    CONFIG_CONTROLLER_HOST=[IP_ADDRESS]
+        # vi [answers-file].txt
+        ...
+        # IP address of the server on which to install OpenStack services
+        # specific to the controller role (for example, API servers or
+        # dashboard).
+        CONFIG_CONTROLLER_HOST=[IP_ADDRESS]
 
-    # List of IP addresses of the servers on which to install the Compute
-    # service.
-    CONFIG_COMPUTE_HOSTS=[IP_ADDRESS],[IP_ADDRESS]
+        # List of IP addresses of the servers on which to install the Compute
+        # service.
+        CONFIG_COMPUTE_HOSTS=[IP_ADDRESS],[IP_ADDRESS]
 
-    # List of IP addresses of the server on which to install the network
-    # service such as Compute networking (nova network) or OpenStack
-    # Networking (neutron).
-    CONFIG_NETWORK_HOSTS=[IP_ADDRESS],[IP_ADDRESS]
-    ...
+        # List of IP addresses of the server on which to install the network
+        # service such as Compute networking (nova network) or OpenStack
+        # Networking (neutron).
+        CONFIG_NETWORK_HOSTS=[IP_ADDRESS],[IP_ADDRESS]
+        ...
 
 
 .. _run-packstack:
@@ -215,64 +224,63 @@ Deploy Additional Hosts
 ```````````````````````
 You can add more hosts after deploying an all-in-one environment. To do so:
 
- 1. In the answers file:
+1. In the :ref:`answers file<answers_file>`:
 
-    - Update the network card names for ``CONFIG_NOVA_COMPUTE_PRIVIF`` and ``CONFIG_NOVA_NETWORK_PRIVIF``.
-    - Update the IP addresses for the ``COMPUTE_HOSTS`` and ``NETWORK_HOSTS``.
-    - Add the IP address of the host on which you've already run Packstack to the ``EXCLUDE_SERVERS`` entry.
+- Update the network card names for ``CONFIG_NOVA_COMPUTE_PRIVIF`` and ``CONFIG_NOVA_NETWORK_PRIVIF``.
+- Update the IP addresses for the ``COMPUTE_HOSTS`` and ``NETWORK_HOSTS``.
+- Add the IP address of the host on which you've already run Packstack to the ``EXCLUDE_SERVERS`` entry.
 
-    Example:
+Example:
 
-    .. code-block:: text
+.. code-block:: text
 
-        # Comma-separated list of servers to be excluded from the
-        # installation. This is helpful if you are running Packstack a second
-        # time with the same answer file and do not want Packstack to
-        # overwrite these server's configurations. Leave empty if you do not
-        # need to exclude any servers.
-        EXCLUDE_SERVERS=10.190.4.193
-        ...
-        # Private interface for flat DHCP on the Compute servers.
-        CONFIG_NOVA_COMPUTE_PRIVIF=enp2s0
-        ...
-        # Private interface for flat DHCP on the Compute network server.
-        CONFIG_NOVA_NETWORK_PRIVIF=enp2s0
-        ...
-        # List of IP addresses of the servers on which to install the Compute
-        # service.
-        CONFIG_COMPUTE_HOSTS=10.190.4.195
+    # Comma-separated list of servers to be excluded from the
+    # installation. This is helpful if you are running Packstack a second
+    # time with the same answer file and do not want Packstack to
+    # overwrite these server's configurations. Leave empty if you do not
+    # need to exclude any servers.
+    EXCLUDE_SERVERS=10.190.4.193
+    ...
+    # Private interface for flat DHCP on the Compute servers.
+    CONFIG_NOVA_COMPUTE_PRIVIF=enp2s0
+    ...
+    # Private interface for flat DHCP on the Compute network server.
+    CONFIG_NOVA_NETWORK_PRIVIF=enp2s0
+    ...
+    # List of IP addresses of the servers on which to install the Compute
+    # service.
+    CONFIG_COMPUTE_HOSTS=10.190.4.195
 
-        # List of IP addresses of the server on which to install the network
-        # service such as Compute networking (nova network) or OpenStack
-        # Networking (neutron).
-        CONFIG_NETWORK_HOSTS=10.190.4.195
+    # List of IP addresses of the server on which to install the network
+    # service such as Compute networking (nova network) or OpenStack
+    # Networking (neutron).
+    CONFIG_NETWORK_HOSTS=10.190.4.195
 
- 2. :ref:`Run packstack <run-packstack>` again.
+2. :ref:`Run packstack <run-packstack>` again.
 
+.. tip::
 
-        .. tip::
+    Run ``ip addr show`` on the host(s) you want to add to find the interface names and IP addresses.
 
-        Run ``ip addr show`` on the host(s) you want to add to find the interface names and IP addresses.
+    .. code-block:: shell
 
-        .. code-block:: shell
-
-            $ ip addr show
-            1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
-                link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
-                inet 127.0.0.1/8 scope host lo
-                   valid_lft forever preferred_lft forever
-                inet6 ::1/128 scope host
-                   valid_lft forever preferred_lft forever
-            2: ens2f0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
-                link/ether 78:e3:b5:0b:61:a4 brd ff:ff:ff:ff:ff:ff
-            3: ens2f1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
-                link/ether 78:e3:b5:0b:61:a6 brd ff:ff:ff:ff:ff:ff
-            4: enp2s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master ovs-system state UP qlen 1000
-                link/ether b4:99:ba:a9:55:f0 brd ff:ff:ff:ff:ff:ff
-                inet6 fe80::b699:baff:fea9:55f0/64 scope link
-                   valid_lft forever preferred_lft forever
-            5: eno1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
-                link/ether b4:99:ba:a9:55:f1 brd ff:ff:ff:ff:ff:ff
+        $ ip addr show
+        1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
+            link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+            inet 127.0.0.1/8 scope host lo
+               valid_lft forever preferred_lft forever
+            inet6 ::1/128 scope host
+               valid_lft forever preferred_lft forever
+        2: ens2f0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
+            link/ether 78:e3:b5:0b:61:a4 brd ff:ff:ff:ff:ff:ff
+        3: ens2f1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
+            link/ether 78:e3:b5:0b:61:a6 brd ff:ff:ff:ff:ff:ff
+        4: enp2s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master ovs-system state UP qlen 1000
+            link/ether b4:99:ba:a9:55:f0 brd ff:ff:ff:ff:ff:ff
+            inet6 fe80::b699:baff:fea9:55f0/64 scope link
+               valid_lft forever preferred_lft forever
+        5: eno1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
+            link/ether b4:99:ba:a9:55:f1 brd ff:ff:ff:ff:ff:ff
 
 
 Configure OpenStack
@@ -283,7 +291,7 @@ You can log in to the Horizon dashboard at the URL provided in the 'successful i
 
 .. tip::
 
-To use the ``openstack``, ``nova``, ``neutron``, and ``glance`` CLI commands, you'll need to source :file:`keystonerc_admin`.
+    To use the ``openstack``, ``nova``, ``neutron``, and ``glance`` CLI commands, you'll need to source :file:`keystonerc_admin`.
 
     .. code-block:: shell
 
@@ -292,7 +300,7 @@ To use the ``openstack``, ``nova``, ``neutron``, and ``glance`` CLI commands, yo
 
 .. note::
 
-You may receive an authentication error when trying to log in to OpenStack Horizon after a session timeout. If this happens, clear
+    You may receive an authentication error when trying to log in to OpenStack Horizon after a session timeout. If this happens, clear
     your browser's cache and delete all cookies, then try logging in again.
 
 

--- a/docs/guides/os-deploy-guide.rst
+++ b/docs/guides/os-deploy-guide.rst
@@ -5,25 +5,22 @@ OpenStack Deployment Guide
 
 Overview
 --------
-
 This guide will allow a user who is largely unfamiliar with OpenStack to create an all-in-one, bare metal installation of `OpenStack RDO <https://www.rdoproject.org/>`_. The instructions presented here guide you through installing an operating system and using `Packstack <https://wiki.openstack.org/wiki/Packstack>`_ to deploy OpenStack.
 
 The information presented here is based on the RDO project `Quickstart guide <https://www.rdoproject.org/install/quickstart/>`_. We've found the RDO documentation set extremely helpful and recommend consulting it for any issues you may encounter.
 
-**CAUTION:** This guide describes how to deploy OpenStack using Packstack. Both are open source projects that are continually changing. You may see some variations between the commands presented here and those available in your environment.
+.. caution::
+
+This guide describes how to deploy OpenStack using Packstack. Both are open source projects that are continually changing. You may see some variations between the commands presented here and those available in your environment.
 
 Prerequisites
 `````````````
+Hardware: Machine with at least 4GB RAM, processors with hardware virtualization extensions, and at least one network adapter. For more information, see the OpenStack installation guide for |openstack|.
 
-Hardware: Machine with at least 4GB RAM, processors with hardware virtualization extensions, and at least one network adapter. For more
-information, see the `OpenStack Kilo Installation guide <http://docs.openstack.org/kilo/install-guide/install/yum/content/ch_overview.html#example-architecture-with-neutron-networking-hw>`_.
-
-Software: Red Hat Enterprise Linux (RHEL) 7 is the minimum recommended version you can use with OpenStack Kilo. You can also use any of the
-equivalent versions of RHEL-based Linux distributions (CentOS, Scientific Linux, etc.). x86\_64 is currently the only supported architecture.
+Software: Red Hat Enterprise Linux (RHEL) 7 is the minimum recommended version you can use with OpenStack |openstack|. You can also use any of the equivalent versions of RHEL-based Linux distributions (CentOS, Scientific Linux, etc.). x86\_64 is currently the only supported architecture.
 
 Releases and Versioning
 ```````````````````````
-
 See :ref:`F5 OpenStack Releases and Support Matrix <releases-and-versioning>`.
 
 Getting Started
@@ -39,10 +36,10 @@ When installing CentOS, create a root user and a user with administrative privel
 admin user is 'manager', with the password 'manager'. In all command blocks shown in this guide, the assumed user is represented by the
 command prompt symbol:
 
-    .. code-block:: text
+.. code-block:: text
 
-        # = root
-        $ = admin
+    # = root
+    $ = admin
 
 
 Disable Network Manager
@@ -53,25 +50,27 @@ interfaces that will be used by OpenStack Networking.
 
 To verify if Network Manager is enabled:
 
-    .. code-block:: text
+.. code-block:: text
 
-         # systemctl status NetworkManager
+     # systemctl status NetworkManager
+
 
 The system displays an error if the Network Manager service is not currently installed:
 
-    .. code-block:: text
+.. code-block:: text
 
-        error reading information on service NetworkManager: No such file or directory
+    error reading information on service NetworkManager: No such file or directory
+
 
 If you see this error, jump ahead to :ref:`Install Software Repositories <install-software-repositories>`.
 
 If Network Manager is running, run the following commands to disable it.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # systemctl stop NetworkManager
-        # systemctl disable NetworkManager
-        # systemctl enable network
+    # systemctl stop NetworkManager
+    # systemctl disable NetworkManager
+    # systemctl enable network
 
 
 .. _install-software-repositories:
@@ -87,19 +86,15 @@ Install Software Repositories
 
         # yum install update -y
 
+
  2. Install the software package for the OpenStack release of your choice. If you want to use the latest release, run:
 
     .. code-block:: text
 
         # yum install -y https://www.rdoproject.org/repos/rdo-release.rpm
 
- 3. To install OpenStack Kilo
 
-    .. code-block:: text
-
-        # yum install -y https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm
-
-    **NOTE:** To install a different OpenStack release, see http://rdoproject.org/repos/ for the full listing.
+     **NOTE:** To install a different OpenStack release, see http://rdoproject.org/repos/ for the full listing.
 
  4. Install the software package for Packstack.
 
@@ -113,117 +108,111 @@ Install Software Repositories
 Deploy OpenStack using Packstack
 --------------------------------
 
-The quickest and easiest way to deploy OpenStack is via Packstack's ``--allinone`` option. This sets up a single machine as the controller,
-compute, and network node. Be aware that this configuration, while fairly simple to execute, is fairly limited. By default, the all-in-one
-configuration doesn't have `Heat <https://wiki.openstack.org/wiki/Heat>`_ and `Neutron LBaaS <https://wiki.openstack.org/wiki/Neutron/LBaaS>`_ enabled. For this reason, **we don't recommend** going with the default ``--allinone`` deployment. Instead, you can customize your all-in-one deployment with an answers file.
+The quickest and easiest way to deploy OpenStack is via Packstack's ``--allinone`` option. This sets up a single machine as the controller, compute, and network node. Be aware that this configuration, while fairly simple to execute, is fairly limited. By default, the all-in-one configuration doesn't have `Heat <https://wiki.openstack.org/wiki/Heat>`_ and `Neutron LBaaS <https://wiki.openstack.org/wiki/Neutron/LBaaS>`_ enabled. For this reason, **we don't recommend** going with the default ``--allinone`` deployment. Instead, you can customize your all-in-one deployment with an answers file.
 
 Custom Configuration with an Answers File
 `````````````````````````````````````````
-
 Instead of using the ``--allinone`` flag, we generated an answers file -- :download:`f5-answers.txt` -- and edited it to enable the services we want and disable some options we don't want.
 
-**NOTE:** The configurations in our answers file are basically equivalent to running the following command:
+.. note::
+The configurations in our answers file are basically equivalent to running the following command:
+.. code-block:: shell
 
-    .. code-block:: shell
-
-        $ packstack --os-heat-install=y --os-debug-mode=y --os-neutron-lbaas-install=y --provision-demo=n
+    $ packstack --os-heat-install=y --os-debug-mode=y --os-neutron-lbaas-install=y --provision-demo=n
 
 To generate an answers file (replace ``[answers-file]`` with the file name of your choice):
 
-    .. code-block:: shell
+.. code-block:: shell
 
-        $ packstack --gen-answer-file=[answers-file].txt
+    $ packstack --gen-answer-file=[answers-file].txt
 
-For our custom all-in-one Kilo installation, we changed the following entries in the answers file. You can also customize your admin user
-account credentials here, if desired.
+For our custom all-in-one installation, we changed the following entries in the answers file. You can also customize your admin user account credentials here, if desired.
 
-    .. code-block:: text
+.. code-block:: text
 
-        # vi [answers-file].txt
-        ...
-        # Specify 'y' to install OpenStack Orchestration (heat). ['y', 'n']
-        CONFIG_HEAT_INSTALL=y
-        ...
-        # Specify 'y' to install Nagios to monitor OpenStack hosts. Nagios
-        # provides additional tools for monitoring the OpenStack environment.
-        # ['y', 'n']
-        CONFIG_NAGIOS_INSTALL=n
-        ...
-        # Specify 'y' if you want to run OpenStack services in debug mode;
-        # otherwise, specify 'n'. ['y', 'n']
-        CONFIG_DEBUG_MODE=y
-        ...
-        # Password to use for the Identity service 'admin' user.
-        CONFIG_KEYSTONE_ADMIN_PW=57a791d9e7d849b4
-        ...
-        # Specify 'y' to enable the EPEL repository (Extra Packages for
-        # Enterprise Linux). ['y', 'n']
-        CONFIG_USE_EPEL=y
-        ...
-        # Specify 'y' to install OpenStack Networking's Load-Balancing-
-        # as-a-Service (LBaaS). ['y', 'n']
-        CONFIG_LBAAS_INSTALL=y
-        ...
-        # Specify 'y' to provision for demo usage and testing. ['y', 'n']
-        CONFIG_PROVISION_DEMO=n
-        ...
+    # vi [answers-file].txt
+    ...
+    # Specify 'y' to install OpenStack Orchestration (heat). ['y', 'n']
+    CONFIG_HEAT_INSTALL=y
+    ...
+    # Specify 'y' to install Nagios to monitor OpenStack hosts. Nagios
+    # provides additional tools for monitoring the OpenStack environment.
+    # ['y', 'n']
+    CONFIG_NAGIOS_INSTALL=n
+    ...
+    # Specify 'y' if you want to run OpenStack services in debug mode;
+    # otherwise, specify 'n'. ['y', 'n']
+    CONFIG_DEBUG_MODE=y
+    ...
+    # Password to use for the Identity service 'admin' user.
+    CONFIG_KEYSTONE_ADMIN_PW=57a791d9e7d849b4
+    ...
+    # Specify 'y' to enable the EPEL repository (Extra Packages for
+    # Enterprise Linux). ['y', 'n']
+    CONFIG_USE_EPEL=y
+    ...
+    # Specify 'y' to install OpenStack Networking's Load-Balancing-
+    # as-a-Service (LBaaS). ['y', 'n']
+    CONFIG_LBAAS_INSTALL=y
+    ...
+    # Specify 'y' to provision for demo usage and testing. ['y', 'n']
+    CONFIG_PROVISION_DEMO=n
+    ...
 
-**NOTE:** When you generate an answers file, Packstack automatically includes the IP address of the machine on which the file is generated in
-the ``CONTROLLER_HOST``, ``COMPUTE_HOSTS``, & ``NETWORK_HOSTS`` entries. If you're using additional compute and/or network nodes, you'll need to
-edit the answers file to add in the IP addresses for those machines. As shown in the example below, multiple values should be comma-separated,
-without a space in between.
+.. note::
 
-    .. code-block:: text
+When you generate an answers file, Packstack automatically includes the IP address of the machine on which the file is generated in
+the ``CONTROLLER_HOST``, ``COMPUTE_HOSTS``, & ``NETWORK_HOSTS`` entries. If you're using additional compute and/or network nodes, you'll need to edit the answers file to add in the IP addresses for those machines. As shown in the example below, multiple values should be comma-separated, without a space in between.
 
-        # vi [answers-file].txt
-        ...
-        # IP address of the server on which to install OpenStack services
-        # specific to the controller role (for example, API servers or
-        # dashboard).
-        CONFIG_CONTROLLER_HOST=[IP_ADDRESS]
+.. code-block:: text
 
-        # List of IP addresses of the servers on which to install the Compute
-        # service.
-        CONFIG_COMPUTE_HOSTS=[IP_ADDRESS],[IP_ADDRESS]
+    # vi [answers-file].txt
+    ...
+    # IP address of the server on which to install OpenStack services
+    # specific to the controller role (for example, API servers or
+    # dashboard).
+    CONFIG_CONTROLLER_HOST=[IP_ADDRESS]
 
-        # List of IP addresses of the server on which to install the network
-        # service such as Compute networking (nova network) or OpenStack
-        # Networking (neutron).
-        CONFIG_NETWORK_HOSTS=[IP_ADDRESS],[IP_ADDRESS]
-        ...
+    # List of IP addresses of the servers on which to install the Compute
+    # service.
+    CONFIG_COMPUTE_HOSTS=[IP_ADDRESS],[IP_ADDRESS]
+
+    # List of IP addresses of the server on which to install the network
+    # service such as Compute networking (nova network) or OpenStack
+    # Networking (neutron).
+    CONFIG_NETWORK_HOSTS=[IP_ADDRESS],[IP_ADDRESS]
+    ...
 
 
 .. _run-packstack:
 
 Run Packstack
 `````````````
-
 To deploy OpenStack using your custom answers file:
 
-    .. code-block:: shell
+.. code-block:: shell
 
-        $ packstack --answer-file=[answers-file].txt
+    $ packstack --answer-file=[answers-file].txt
 
 
 The installation can take a while. If all goes well, you should eventually see the following message:
 
-    .. code-block:: text
+.. code-block:: text
 
-        **** Installation completed successfully ******
+    **** Installation completed successfully ******
 
-        Additional information:
-         * Time synchronization installation was skipped. Please note that unsynchronized time on server instances might be problem for some OpenStack components.
-         * File /root/keystonerc_admin has been created on OpenStack client host 10.190.4.193. To use the command line tools you need to source the file.
-         * Copy of keystonerc_admin file has been created for non-root user in /home/manager.
-         * To access the OpenStack Dashboard browse to http://10.190.4.193/dashboard.
-        Please, find your login credentials stored in the keystonerc_admin in your home directory.
-         * The installation log file is available at: /var/tmp/packstack/20160121-155701-AyFMdp/openstack-setup.log
-         * The generated manifests are available at: /var/tmp/packstack/20160121-155701-AyFMdp/manifests
+    Additional information:
+     * Time synchronization installation was skipped. Please note that unsynchronized time on server instances might be problem for some OpenStack components.
+     * File /root/keystonerc_admin has been created on OpenStack client host 10.190.4.193. To use the command line tools you need to source the file.
+     * Copy of keystonerc_admin file has been created for non-root user in /home/manager.
+     * To access the OpenStack Dashboard browse to http://10.190.4.193/dashboard.
+    Please, find your login credentials stored in the keystonerc_admin in your home directory.
+     * The installation log file is available at: /var/tmp/packstack/20160121-155701-AyFMdp/openstack-setup.log
+     * The generated manifests are available at: /var/tmp/packstack/20160121-155701-AyFMdp/manifests
 
 
 Deploy Additional Hosts
 ```````````````````````
-
 You can add more hosts after deploying an all-in-one environment. To do so:
 
  1. In the answers file:
@@ -261,45 +250,49 @@ You can add more hosts after deploying an all-in-one environment. To do so:
  2. :ref:`Run packstack <run-packstack>` again.
 
 
-    **TIP:** Run ``ip addr show`` on the host(s) you want to add to find the interface names and IP addresses.
+        .. tip::
 
-    .. code-block:: shell
+        Run ``ip addr show`` on the host(s) you want to add to find the interface names and IP addresses.
 
-        $ ip addr show
-        1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
-            link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
-            inet 127.0.0.1/8 scope host lo
-               valid_lft forever preferred_lft forever
-            inet6 ::1/128 scope host
-               valid_lft forever preferred_lft forever
-        2: ens2f0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
-            link/ether 78:e3:b5:0b:61:a4 brd ff:ff:ff:ff:ff:ff
-        3: ens2f1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
-            link/ether 78:e3:b5:0b:61:a6 brd ff:ff:ff:ff:ff:ff
-        4: enp2s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master ovs-system state UP qlen 1000
-            link/ether b4:99:ba:a9:55:f0 brd ff:ff:ff:ff:ff:ff
-            inet6 fe80::b699:baff:fea9:55f0/64 scope link
-               valid_lft forever preferred_lft forever
-        5: eno1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
-            link/ether b4:99:ba:a9:55:f1 brd ff:ff:ff:ff:ff:ff
+        .. code-block:: shell
+
+            $ ip addr show
+            1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
+                link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+                inet 127.0.0.1/8 scope host lo
+                   valid_lft forever preferred_lft forever
+                inet6 ::1/128 scope host
+                   valid_lft forever preferred_lft forever
+            2: ens2f0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
+                link/ether 78:e3:b5:0b:61:a4 brd ff:ff:ff:ff:ff:ff
+            3: ens2f1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
+                link/ether 78:e3:b5:0b:61:a6 brd ff:ff:ff:ff:ff:ff
+            4: enp2s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master ovs-system state UP qlen 1000
+                link/ether b4:99:ba:a9:55:f0 brd ff:ff:ff:ff:ff:ff
+                inet6 fe80::b699:baff:fea9:55f0/64 scope link
+                   valid_lft forever preferred_lft forever
+            5: eno1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN qlen 1000
+                link/ether b4:99:ba:a9:55:f1 brd ff:ff:ff:ff:ff:ff
 
 
 Configure OpenStack
 -------------------
-
-Congratulations! You now have an OpenStack deployment. Next, you'll need to configure your network, add projects and users, and launch instances.
-Please see our :ref:`OpenStack configuration guide <os-config-guide>` for instructions.
+Congratulations! You now have an OpenStack deployment. Next, you'll need to configure your network, add projects and users, and launch instances. Please see our :ref:`OpenStack configuration guide <os-config-guide>` for instructions.
 
 You can log in to the Horizon dashboard at the URL provided in the 'successful installation' message, using the username and password found in :file:`keystonerc_admin`. **If you change your password in Horizon, be sure to update this file.**
 
-**TIPS:**
+.. tip::
 
-- To use the ``openstack``, ``nova``, ``neutron``, and ``glance`` CLI commands, you'll need to source :file:`keystonerc_admin`.
+To use the ``openstack``, ``nova``, ``neutron``, and ``glance`` CLI commands, you'll need to source :file:`keystonerc_admin`.
 
     .. code-block:: shell
 
         $ source keystonerc_admin
 
--   You may receive an authentication error when trying to log in to OpenStack Horizon after a session timeout. If this happens, clear
+
+.. note::
+
+You may receive an authentication error when trying to log in to OpenStack Horizon after a session timeout. If this happens, clear
     your browser's cache and delete all cookies, then try logging in again.
+
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,62 +42,48 @@ Projects
 --------
 All of F5 Networks' OpenStack projects are open source and can be found at `githib.com/F5Networks <https://github.com/F5Networks>`_. The OpenStack-specific projects are all prefaced by 'f5-openstack'; two additional F5 projects that are used by the F5 OpenStack projects are also noted below.
 
-f5-openstack-lbaasv1
-~~~~~~~~~~~~~~~~~~~~
+f5-openstack-lbaasv1_
+~~~~~~~~~~~~~~~~~~~~~
 This repo contains the code for the F5 OpenStack LBaaSv1 plugin.
 
-`F5Networks/f5-openstack-lbaasv1 <https://github.com/F5Networks/f5-openstack-lbaasv1>`_
-`Documentation <http://f5-openstack-lbaasv1.readthedocs.org/en/>`_
+`LBaaSv1 Documentation <http://f5-openstack-lbaasv1.readthedocs.org/en/>`_
 
-f5-openstack-lbaasv2-plugin
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+f5-openstack-lbaasv2-plugin_
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This repo contains the code for the F5 OpenStack LBaaSv2 plugin.
 
-`F5Networks/f5-openstack-lbaasv2-plugin <https://github.com/F5Networks/f5-openstack-lbaasv2-plugin>`_
+`LBaaSv2 Plugin Documentation <http://f5-openstack-lbaasv2-plugin.readthedocs.org/en/>`_
 
-`Documentation <http://f5-openstack-lbaasv2-plugin.readthedocs.org/en/>`_
-
-f5-openstack-lbaasv2-driver
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+f5-openstack-lbaasv2-driver_
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This repo contains the code for the F5 OpenStack LBaaSv2 service provider driver, which is part of the LBaaSv2 plugin.
 
-`F5Networks/f5-openstack-lbaasv2-driver <https://github.com/F5Networks/f5-openstack-lbaasv2-driver>`_
+`LBaaSv2 Driver Documentation <http://f5-openstack-lbaasv2-driver.readthedocs.org/en/>`_
 
-`Documentation <http://f5-openstack-lbaasv2-driver.readthedocs.org/en/>`_
-
-f5-openstack-heat
-~~~~~~~~~~~~~~~~~
+f5-openstack-heat_
+~~~~~~~~~~~~~~~~~~
 This repo contains supported and unsupported Heat templates. These can be used to simplify and automate the deployment and configuration of BIG-IP devices in OpenStack.
 
-`F5Networks/f5-openstack-heat <https://github.com/F5Networks/f5-openstack-heat>`_
+`F5 OpenStack Heat Documentation <http://f5-openstack-heat.readthedocs.org/en/>`_
 
-`Documentation <http://f5-openstack-heat.readthedocs.org/en/>`_
-
-f5-openstack-heat-plugins
-~~~~~~~~~~~~~~~~~~~~~~~~~
+f5-openstack-heat-plugins_
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 This repo contains code for the plugins that make the Heat templates work.
 
-`F5Networks/f5-openstack-heat-plugins <https://github.com/F5Networks/f5-openstack-heat-plugins>`_
+`F5 OpenStack Heat Plugins Documentation <http://f5-openstack-heat-plugins.readthedocs.org/en/>`_
 
-`Documentation <http://f5-openstack-heat-plugins.readthedocs.org/en/>`_
-
-f5-icontrol-rest-python
-~~~~~~~~~~~~~~~~~~~~~~~
+f5-icontrol-rest-python_
+~~~~~~~~~~~~~~~~~~~~~~~~
 This generic python library allows programs and other modules to interact with the BIG-IP iControl REST API.
 
-`F5Networks/f5-icontrol-rest-python <https://github.com/F5Networks/f5-icontrol-rest-python>`_
+`F5 iControl REST Python Documentation <http://icontrol.readthedocs.org/en/latest/>`_
 
-`Documentation <http://icontrol.readthedocs.org/en/latest/>`_
-
-f5-common-python
-~~~~~~~~~~~~~~~~
+f5-common-python_
+~~~~~~~~~~~~~~~~~
 The F5 Networks BIG-IP python SDK. This project implements an SDK for the iControl REST interface for the BigIP.
 
-`F5Networks/f5-common-python <https://github.com/F5Networks/f5-common-python>`_
-
-`Documentation <https://f5-sdk.readthedocs.org/en/latest/>`_
+`F5 Python SDK Documentation <https://f5-sdk.readthedocs.org/en/latest/>`_
 
 
 Releases and Versioning
@@ -149,3 +135,11 @@ have completed and submitted the :ref:`F5 Contributor License Agreement <cla_lan
 to Openstack_CLA@f5.com prior to their code submission being included
 in this project.
 
+
+.. _f5-openstack-lbaasv1: https://github.com/F5Networks/f5-openstack-lbaasv1
+.. _f5-openstack-lbaasv2-plugin: https://github.com/F5Networks/f5-openstack-lbaasv2-plugin
+.. _f5-openstack-lbaasv2-driver: https://github.com/F5Networks/f5-openstack-lbaasv2-driver
+.. _f5-openstack-heat: https://github.com/F5Networks/f5-openstack-heat
+.. _f5-openstack-heat-plugins: https://github.com/F5Networks/f5-openstack-heat-plugins
+.. _f5-icontrol-rest-python: https://github.com/F5Networks/f5-icontrol-rest-python>
+.. _f5common-python: https://github.com/F5Networks/f5-common-python>


### PR DESCRIPTION
Fixes #85, #84  

Cleanup:
- changed all instances of `**NOTE:**`, `**TIP:**`, etc., to the appropriate pre-formatted block (`.. note::`, `.. tip::`, etc.).
- edited down the create vlans section in the ve deploy guide to eliminate redundancy