### PR TITLE
Update OpenStack version download URL

### DIFF
--- a/docs/guides/os-deploy-guide.rst
+++ b/docs/guides/os-deploy-guide.rst
@@ -89,16 +89,11 @@ Install Software Repositories
         # yum install update -y
 
 
-2. Install the software package for the OpenStack release of your choice. If you want to use the latest release, run:
+2. Install the software package for the OpenStack |openstack| release:
 
     .. code-block:: text
 
-        # yum install -y https://www.rdoproject.org/repos/rdo-release.rpm
-
-
-    .. note::
-
-        To install a different OpenStack release, see http://rdoproject.org/repos/ for the full listing.
+        # yum install -y https://repos.fedorapeople.org/repos/openstack/openstack-liberty/rdo-release-liberty-1.noarch.rpm
 
 
 3. Install the software package for Packstack.


### PR DESCRIPTION
Fixes #113

Problem: I need to update the download URL for the OpenStack release in the deploy guide.

Analysis: I replaced the current URL (which points to the latest release) with the URL for liberty.