### PR TITLE
Match doc version to corresponding OpenStack version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,9 +65,9 @@ author = u'F5 Networks'
 # built documents.
 #
 # The short X.Y version.
-version = u'1.0'
+version = u'Kilo'
 # The full version, including alpha/beta/rc tags.
-release = u'1.0'
+release = u'Kilo'
 
 # OpenStack release
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -305,10 +305,10 @@ texinfo_documents = [
 # intersphinx_mapping = {'https://docs.python.org/': None}
 
 intersphinx_mapping = {'heat': (
-    'http://f5-openstack-heat.readthedocs.org/en/latest', None),
+    'http://f5-openstack-heat.readthedocs.io/en/kilo', None),
     'lbaasv1': (
-    'http://f5-openstack-lbaasv1.readthedocs.org/en/latest', None),
+    'http://f5-openstack-lbaasv1.readthedocs.io/en/1.0/', None),
     'lbaasv2': (
-    'http://f5-openstack-lbaasv2.readthedocs.org/en/latest', None),
+    'http://f5-openstack-lbaasv2.readthedocs.io/en/liberty/', None),
     }
 

--- a/docs/guides/includes/concept_provider-network.rst
+++ b/docs/guides/includes/concept_provider-network.rst
@@ -10,11 +10,11 @@ In a flat, or untagged, provider network, all instances reside on the same netwo
 Provider Networks and BIG-IP®
 `````````````````````````````
 
-BIG-IP® can work with either type of provider network. Users with VLAN provider networks can use the F5® LBaaS plugins in :ref:`global routed mode <lbaasv2:global-routed-mode>` or :ref:`L2/L3-adjacent mode <lbaasv2:l2-l3-adjacent-mode>` to provision services from BIG-IP®. Users with a flat provider network must use the F5® LBaaS plugins in global routed mode with a BIG-IP® deployed within OpenStack (what we call 'overcloud'). If BIG-IP® is deployed externally (what we call 'undercloud'), the :ref:`F5® agent <lbaasv2:agent>` must be configured to use L2/L3-adjacent mode.
+BIG-IP® can work with either type of provider network. Users with VLAN provider networks can use the :ref:`F5® LBaaS plugins <lbaasv1:f5-lbaasv1-plugin-architecture-overview>` in :ref:`global routed mode <lbaasv1:global-routed-mode>` or :ref:`L2-adjacent mode <lbaasv1:l2-adjacent-mode>` to provision services from BIG-IP®. Users with a flat provider network must use the F5® LBaaS plugins in global routed mode with a BIG-IP® deployed within OpenStack (referred to as :dfn:`overcloud`). If BIG-IP® is deployed externally (referred to as :dfn:`undercloud`), the F5® agent must be configured to use L2/L3-adjacent mode.
 
 .. seealso::
 
-    * `OpenStack Networking Guide <http://docs.openstack.org/liberty/networking-guide/intro-os-networking-overview.html>`_ (Liberty)
+    * `OpenStack Networking Guide <http://docs.openstack.org/kilo/networking-guide/>`_
     * :ref:`F5® LBaaSv1 Plugin Documentation <lbaasv1:home>`
     * :ref:`F5® LBaaSv2 Plugin Documentation <lbaasv2:home>`
 

--- a/docs/guides/includes/ref_deploy-guide-next-steps.rst
+++ b/docs/guides/includes/ref_deploy-guide-next-steps.rst
@@ -11,6 +11,6 @@ Now that your BIG-IP® VE is running, you will need to configure it. See :ref:`F
 
 .. tip::
 
-    To log in to the BIG-IP® GUI, copy its floating IP from the :guilabel:`Instance` screen in the dashboard, then paste it into your browser's address bar. You must use **https** to connect.
+    To log in to the BIG-IP® GUI, copy its floating IP from the :guilabel:`Instance` screen in the dashboard, then paste it into your browser's address bar. **You must use** ``https`` **to connect**.
 
     Use either the `system default <https://support.f5.com/kb/en-us/solutions/public/13000/100/sol13148.html>`_ username and password, or credentials defined during :ref:`onboarding <heat:how-to_onboard-ve>`, to log in.

--- a/docs/guides/includes/topic_os-deploy-install-software-repos.rst
+++ b/docs/guides/includes/topic_os-deploy-install-software-repos.rst
@@ -18,7 +18,7 @@ Install Software Repositories
 
     .. code-block:: shell
 
-        $ sudo install -y https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm
+        $ sudo install -y https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-2.noarch.rpm
 
 
 3. Install the software package for Packstack.


### PR DESCRIPTION
@mattgreene -- FYI

#### What issues does this address?
Fixes #137
...

#### What's this change do?
- Updates the doc version in conf.py and elsewhere to match the corresponding OpenStack version name. 
- Updates the URLs in conf.py for intersphinx mapping to point to the corresponding version of external doc sets (kilo for heat and lbaasv1; still points to liberty for lbaasv2 since there is no kilo branch for lbaasv2).

#### Where should the reviewer start?

Review changes below.

#### Any background context?
