### PR TITLE
Docs index page refactor

### DIFF
--- a/docs/branching_strategy.rst
+++ b/docs/branching_strategy.rst
@@ -1,5 +1,5 @@
-F5® Development Branching Strategy
-==================================
+F5 Development Branching Strategy
+=================================
 
 .. important:: Development for all F5® OpenStack projects in GitHub follows this branching strategy.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,21 +12,21 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-#import sys
-#import os
-#import os.path
+# import sys
+# import os
+# import os.path
 import six
 print "six version:", six.__version__
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.4'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -39,7 +39,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.autosectionlabel'
+    'sphinx.ext.autosectionlabel',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -306,10 +306,16 @@ texinfo_documents = [
 # intersphinx_mapping = {'https://docs.python.org/': None}
 
 intersphinx_mapping = {'heat': (
-    'http://f5-openstack-heat.readthedocs.io/en/kilo', None),
+    'http://f5-openstack-heat.readthedocs.io/en/latest', None),
+    'heatplugins': (
+    'http://f5-openstack-heat-plugins.readthedocs.io/en/latest', None),
     'lbaasv1': (
     'http://f5-openstack-lbaasv1.readthedocs.io/en/1.0/', None),
-    #'lbaasv2': (
-    #'http://f5-openstack-lbaasv2-driver.readthedocs.io/en/liberty', None),
+    'lbaasv2': (
+    'http://f5-openstack-lbaasv2-driver.readthedocs.io/en/latest', None),
+    'agent': (
+    'http://f5-openstack-agent.readthedocs.io/en/latest', None),
+    'f5sdk': (
+    'http://f5-sdk.readthedocs.io/en/latest/', None),
     }
 

--- a/docs/guides/map_developers.rst
+++ b/docs/guides/map_developers.rst
@@ -7,9 +7,10 @@ Contents
 --------
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
-    ../branching_strategy.rst
+    ../branching_strategy
+    ../cla_landing
 
 
 Reference Materials

--- a/docs/howto_deploy-ve-openstack.rst
+++ b/docs/howto_deploy-ve-openstack.rst
@@ -1,7 +1,7 @@
 .. _deploy_big-ip_openstack:
 
-How To Deploy BIG-IP® VE in OpenStack
-=====================================
+How To Deploy BIG-IP VE in OpenStack
+====================================
 
 .. include:: guides/includes/concept_ve-deploy-guide-overview.rst
     :start-line: 5

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,27 +23,28 @@ F5 OpenStack Documentation
 
     <script async defer src="https://f5-openstack-slack.herokuapp.com/slackin.js"></script>
 
+This documentation set provides users of F5® technologies with an interest in OpenStack a jumping-off point for getting started with F5 in OpenStack. We have guides for simple OpenStack :ref:`deployment <os-deploy-guide>` and :ref:`configuration <os-config-guide>` and for :ref:`deploying BIG-IP® VE <deploy_big-ip_openstack>` from within an OpenStack cloud.
+
+If you would like to request a new user guide or notify us of an issue with an existing one, please file an `issue <https://github.com/F5Networks/f5-openstack-docs/issues>`_ in GitHub.
 
 User Guides and Resources
 *************************
 
-Guides
-------
-
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
+    project_index
+    releases_and_versioning
     openstack-deploy-guide
     openstack-config-guide
     howto_deploy-ve-openstack
-    releases_and_versioning
+    guides/map_developers
 
 
 Releases and Support
 --------------------
 
-The user guides provided here support OpenStack |openstack|. See the :ref:`F5® Releases and Support Matrix <releases-and-support>` for more information.
-
+The user guides provided here support OpenStack |openstack|. See the :ref:`F5 Releases and Support Matrix <releases-and-support>` for more information.
 
 For Developers
 --------------
@@ -51,48 +52,55 @@ For Developers
 Interested in contributing to an F5 OpenStack project? Check out the :ref:`Developer Area`.
 
 
-Project Index
-*************
+F5 in OpenStack
+***************
 
-All of F5's OpenStack projects are open source and can be found in GitHub at `githib.com/F5Networks <https://github.com/F5Networks>`_.
-
-`f5-openstack-agent`_
----------------------
-
-This repo contains the code for the F5® OpenStack agent.
-
-Agent documentation is included in the `LBaaSv2 Documentation <http://f5-openstack-lbaasv2.readthedocs.io/>`_.
-
-`f5-openstack-lbaasv2-driver`_
-------------------------------
-
-This repo contains the code for the F5® OpenStack LBaaSv2 service provider driver, which is part of the LBaaSv2 plugin.
-
-LBaaSv2 Driver documentation is included in the `LBaaSv2 Documentation <http://f5-openstack-lbaasv2.readthedocs.io>`_.
-
-`f5-openstack-heat`_
---------------------
-
-This repo contains supported and unsupported Heat templates. These can be used to simplify and automate the deployment and configuration of BIG-IP® Virtual Edition (VE) in OpenStack.
-
-`F5® OpenStack Heat Documentation <http://f5-openstack-heat.readthedocs.io>`_
-
-`f5-openstack-heat-plugins`_
-----------------------------
-
-This repo contains code for the plugins that make the Heat templates work.
-
-`F5® OpenStack Heat Plugins Documentation <http://f5-openstack-heat-plugins.readthedocs.io>`_
+F5 currently has a presence in the `OpenStack projects <http://www.openstack.org/software/project-navigator>`_ listed below. Please see our :ref:`Project index` for more information.
 
 
+Neutron LBaaS
+-------------
+
+`Neutron <http://www.openstack.org/software/releases/kilo/components/neutron>`_ is the OpenStack Networking component. The Load-Balancer-as-a-Service (LBaaS) plugin adds load balancing functionality to Neutron. There are two versions -- LBaaSv1 and LBaaSv2 -- for both of which F5 provides tools that enable users to provision BIG-IP® services in OpenStack.
+
+v1
+~~~~
+
+Neutron LBaaSv1 is compatible with OpenStack Juno - Liberty; it was deprecated with the Liberty release.
+
+.. seealso::
+
+    * `f5-openstack-lbaasv1 on GitHub <https://github.com/F5Networks/f5-openstack-lbaasv1>`_
+    * :ref:`F5 LBaaSv1 Plugin Docs Home <lbaasv1:home>`
 
 
-.. _f5-openstack-lbaasv1: https://github.com/F5Networks/f5-openstack-lbaasv1
-.. _f5-openstack-agent: https://github.com/F5Networks/f5-openstack-agent
-.. _f5-openstack-lbaasv2-driver: https://github.com/F5Networks/f5-openstack-lbaasv2-driver
-.. _f5-openstack-heat: https://github.com/F5Networks/f5-openstack-heat
-.. _f5-openstack-heat-plugins: https://github.com/F5Networks/f5-openstack-heat-plugins
-.. _f5-icontrol-rest-python: https://github.com/F5Networks/f5-icontrol-rest-python
-.. _f5common-python: https://github.com/F5Networks/f5-common-python>
+v2
+~~~~
+
+Neutron LBaaSv2 replaced LBaaSv1 in the Liberty release; it is compatible with Liberty and later releases. For LBaaSv2, F5 split its solution into two separate projects: :ref:`f5-openstack-agent <agent:home>` and :ref:`f5-openstack-lbaasv2-driver <lbaasv2:home>`.
+
+.. seealso::
+
+    * `f5-openstack-agent on GitHub <https://github.com/F5Networks/f5-openstack-agent>`_
+    * `f5-openstack-lbaasv2-driver on GitHub <https://github.com/F5Networks/f5-openstack-lbaasv2-driver>`_
+    * :ref:`F5 Agent Docs Home <agent:home>`
+    * :ref:`F5 LBaaSv2 Docs Home <lbaasv2:home>`
+    * :ref:`F5 LBaaSv2 User Guide <lbaasv2:F5® OpenStack LBaaSv2 User Guide>`
+
+
+Heat
+----
+
+`Heat <http://www.openstack.org/software/releases/kilo/components/heat>`_ is OpenStack's orchestration service. F5 has developed a set of Heat :ref:`plugins <heatplugins:home>` and :ref:`templates <heat:home>` that make it easy to orchestrate cloud applications in OpenStack using F5 technologies.
+
+.. seealso::
+
+    * `f5-openstack-heat-plugins on GitHub <https://github.com/F5Networks/f5-openstack-heat-plugins>`_
+    * `f5-openstack-heat on GitHub <https://github.com/F5Networks/f5-openstack-heat>`_
+    * :ref:`F5 Heat Plugins Docs Home <heatplugins:home>`
+    * :ref:`F5 Heat Docs Home <heat:home>`
+    * :ref:`F5 Heat User Guide <heat:heat-user-guide>`
+
+
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,8 +27,8 @@ This documentation set provides users of F5® technologies with an interest in O
 
 If you would like to request a new user guide or notify us of an issue with an existing one, please file an `issue <https://github.com/F5Networks/f5-openstack-docs/issues>`_ in GitHub.
 
-User Guides and Resources
-*************************
+Guides and Resources
+********************
 
 .. toctree::
     :maxdepth: 1
@@ -51,55 +51,6 @@ For Developers
 
 Interested in contributing to an F5 OpenStack project? Check out the :ref:`Developer Area`.
 
-
-F5 in OpenStack
-***************
-
-F5 currently has a presence in the `OpenStack projects <http://www.openstack.org/software/project-navigator>`_ listed below. Please see our :ref:`Project index` for more information.
-
-
-Neutron LBaaS
--------------
-
-`Neutron <http://www.openstack.org/software/releases/kilo/components/neutron>`_ is the OpenStack Networking component. The Load-Balancer-as-a-Service (LBaaS) plugin adds load balancing functionality to Neutron. There are two versions -- LBaaSv1 and LBaaSv2 -- for both of which F5 provides tools that enable users to provision BIG-IP® services in OpenStack.
-
-v1
-~~~~
-
-Neutron LBaaSv1 is compatible with OpenStack Juno - Liberty; it was deprecated with the Liberty release.
-
-.. seealso::
-
-    * `f5-openstack-lbaasv1 on GitHub <https://github.com/F5Networks/f5-openstack-lbaasv1>`_
-    * :ref:`F5 LBaaSv1 Plugin Docs Home <lbaasv1:home>`
-
-
-v2
-~~~~
-
-Neutron LBaaSv2 replaced LBaaSv1 in the Liberty release; it is compatible with Liberty and later releases. For LBaaSv2, F5 split its solution into two separate projects: :ref:`f5-openstack-agent <agent:home>` and :ref:`f5-openstack-lbaasv2-driver <lbaasv2:home>`.
-
-.. seealso::
-
-    * `f5-openstack-agent on GitHub <https://github.com/F5Networks/f5-openstack-agent>`_
-    * `f5-openstack-lbaasv2-driver on GitHub <https://github.com/F5Networks/f5-openstack-lbaasv2-driver>`_
-    * :ref:`F5 Agent Docs Home <agent:home>`
-    * :ref:`F5 LBaaSv2 Docs Home <lbaasv2:home>`
-    * :ref:`F5 LBaaSv2 User Guide <lbaasv2:F5® OpenStack LBaaSv2 User Guide>`
-
-
-Heat
-----
-
-`Heat <http://www.openstack.org/software/releases/kilo/components/heat>`_ is OpenStack's orchestration service. F5 has developed a set of Heat :ref:`plugins <heatplugins:home>` and :ref:`templates <heat:home>` that make it easy to orchestrate cloud applications in OpenStack using F5 technologies.
-
-.. seealso::
-
-    * `f5-openstack-heat-plugins on GitHub <https://github.com/F5Networks/f5-openstack-heat-plugins>`_
-    * `f5-openstack-heat on GitHub <https://github.com/F5Networks/f5-openstack-heat>`_
-    * :ref:`F5 Heat Plugins Docs Home <heatplugins:home>`
-    * :ref:`F5 Heat Docs Home <heat:home>`
-    * :ref:`F5 Heat User Guide <heat:heat-user-guide>`
 
 
 

--- a/docs/project_index.rst
+++ b/docs/project_index.rst
@@ -1,0 +1,77 @@
+.. _project-index:
+
+Project Index
+#############
+
+F5 Networks® produces a number of open source plugins and tools which make it easier to use F5® products, such as BIG-IP®, in conjunction with OpenStack clouds. All of our OpenStack projects are developed in GitHub at `github.com/F5Networks <https://github.com/F5Networks>`_.
+
+LBaaSv1
+*******
+
+F5's :ref:`LBaaSv1 plugin <lbaasv1:home>` is supported for use with OpenStack Juno - Liberty. LBaaSv1 was deprecated in the Liberty release.
+
+The LBaaSv1 plugin is an :ref:`all-in-one solution <lbaasv1:f5-lbaasv1-plugin-architecture-overview>`, comprising the F5 agent, driver, and common (a predecessor to the :ref:`f5-sdk <f5sdk:F5 Python SDK Documentation>`) libraries.
+
+.. seealso::
+
+    * `F5 LBaaSv1 Docs Home <http://f5-openstack-lbaasv1.readthedocs.io>`_
+    * `f5-openstack-lbaasv1 on GitHub <https://github.com/F5Networks/f5-openstack-lbaasv1>`_
+
+LBaaSv2
+*******
+
+F5's LBaaSv2 solution is supported for use with OpenStack Liberty forward. [#]_ Unlike the F5 LBaaSv1 solution, for LBaaSv2 the agent and driver are developed as **separate** projects.
+
+f5-openstack-lbaasv2-driver
+---------------------------
+
+The F5 OpenStack service provider driver -- also referred to as the F5 LBaaSv2 driver -- directs Neutron load balancing calls from the RPC messaging queue to the F5 agent.
+
+.. seealso::
+
+    * :ref:`F5 LBaaSv2 Docs Home <lbaasv2:home>`
+    * :ref:`F5 LBaaSv2 User Guide <lbaasv2:F5® OpenStack LBaaSv2 User Guide>`
+    * `f5-openstack-lbaasv2-driver on GitHub <https://github.com/F5Networks/f5-openstack-lbaasv2-driver>`_
+
+f5-openstack-agent
+------------------
+
+The F5 agent provides OpenStack users with access to the robust set of `BIG-IP® LTM® <https://f5.com/products/modules/local-traffic-manager>`_ services. It uses the `f5-sdk <f5sdk:F5 Python SDK Documentation>` to translate messaging calls from OpenStack to iControl® REST calls that are understood by BIG-IP devices.
+
+In the future, the agent may also provide the means for using such OpenStack services as `FWaaS <https://wiki.openstack.org/wiki/Neutron/FWaaS>`_ and `VPNaaS <https://wiki.openstack.org/wiki/Neutron/VPNaaS>`_ in conjunction with BIG-IP devices.
+
+.. seealso::
+
+    * :ref:`F5 Agent Docs Home <agent:home>`
+    * :ref:`F5 Agent Quick Start <agent:Quick Start>`
+    * `f5-openstack-agent on GitHub <https://github.com/F5Networks/f5-openstack-agent>`_
+
+
+.. rubric:: Footnotes
+.. [#] See the :ref:`Releases and Support Matrix <releases-and-support>`
+
+
+Heat
+****
+
+Plugins
+-------
+
+The :ref:`F5 Heat plugins <heatplugins:home>` enable BIG-IP objects for use in OpenStack. Like the F5 LBaaSv2 agent, the plugins use the :ref:`f5-sdk <f5sdk:F5 Python SDK Documentation>` to communicate with BIG-IP via the REST API.
+
+
+Templates
+---------
+
+The :ref:`F5 Heat templates <heat:home>` can be used to provision resources and BIG-IP services in OpenStack clouds. F5's templates use the OpenStack HOT template format; they can be used in conjunction with `F5 iApps® <https://devcentral.f5.com/wiki/iApp.HomePage.ashx>`_, a user-customizable framework for deploying applications.
+
+The F5 Heat templates come in two flavors: :ref:`supported <heat:f5-supported_home>` and :ref:`unsupported <heat:unsupported_home>`. All F5 Heat templates can be downloaded from the F5 Heat :ref:`docs site <heat:home>`.
+
+.. warning::
+
+    F5 provides limited support for :ref:`supported <heat:f5-supported_home>` templates, while :ref:`unsupported <heat:unsupported_home>` templates are considered to be 'use-at-your-own-risk'.
+    
+
+
+
+

--- a/docs/project_index.rst
+++ b/docs/project_index.rst
@@ -1,12 +1,20 @@
 .. _project-index:
 
+
 Project Index
 #############
 
-F5 Networks® produces a number of open source plugins and tools which make it easier to use F5® products, such as BIG-IP®, in conjunction with OpenStack clouds. All of our OpenStack projects are developed in GitHub at `github.com/F5Networks <https://github.com/F5Networks>`_.
+F5 currently has a presence in the `OpenStack projects <http://www.openstack.org/software/project-navigator>`_ listed below.
+
+
+Neutron
+*******
+
+`Neutron <http://www.openstack.org/software/releases/kilo/components/neutron>`_ is the OpenStack Networking component. The Load-Balancer-as-a-Service (LBaaS) plugin adds load balancing functionality to Neutron. There are two versions -- LBaaSv1 and LBaaSv2 -- for both of which F5 provides tools that enable users to provision BIG-IP® services in OpenStack.
 
 LBaaSv1
-*******
+=======
+
 
 F5's :ref:`LBaaSv1 plugin <lbaasv1:home>` is supported for use with OpenStack Juno - Liberty. LBaaSv1 was deprecated in the Liberty release.
 
@@ -14,11 +22,11 @@ The LBaaSv1 plugin is an :ref:`all-in-one solution <lbaasv1:f5-lbaasv1-plugin-ar
 
 .. seealso::
 
-    * `F5 LBaaSv1 Docs Home <http://f5-openstack-lbaasv1.readthedocs.io>`_
     * `f5-openstack-lbaasv1 on GitHub <https://github.com/F5Networks/f5-openstack-lbaasv1>`_
+    * :ref:`F5 LBaaSv1 Plugin Docs Home <lbaasv1:home>`
 
 LBaaSv2
-*******
+=======
 
 F5's LBaaSv2 solution is supported for use with OpenStack Liberty forward. [#]_ Unlike the F5 LBaaSv1 solution, for LBaaSv2 the agent and driver are developed as **separate** projects.
 
@@ -30,7 +38,7 @@ The F5 OpenStack service provider driver -- also referred to as the F5 LBaaSv2 d
 .. seealso::
 
     * :ref:`F5 LBaaSv2 Docs Home <lbaasv2:home>`
-    * :ref:`F5 LBaaSv2 User Guide <lbaasv2:F5® OpenStack LBaaSv2 User Guide>`
+    * :ref:`F5 LBaaSv2 User Guide <lbaasv2:F5 OpenStack LBaaSv2 User Guide>`
     * `f5-openstack-lbaasv2-driver on GitHub <https://github.com/F5Networks/f5-openstack-lbaasv2-driver>`_
 
 f5-openstack-agent
@@ -54,24 +62,35 @@ In the future, the agent may also provide the means for using such OpenStack ser
 Heat
 ****
 
+`Heat <http://www.openstack.org/software/releases/kilo/components/heat>`_ is OpenStack's orchestration service. F5 has developed a set of Heat :ref:`plugins <heatplugins:home>` and :ref:`templates <heat:home>` that make it easy to orchestrate cloud applications in OpenStack using F5 technologies.
+
 Plugins
--------
+=======
 
 The :ref:`F5 Heat plugins <heatplugins:home>` enable BIG-IP objects for use in OpenStack. Like the F5 LBaaSv2 agent, the plugins use the :ref:`f5-sdk <f5sdk:F5 Python SDK Documentation>` to communicate with BIG-IP via the REST API.
 
+.. seealso::
+
+    * `f5-openstack-heat-plugins on GitHub <https://github.com/F5Networks/f5-openstack-heat-plugins>`_
+    * :ref:`F5 Heat Plugins Docs Home <heatplugins:home>`
+
 
 Templates
----------
+=========
 
-The :ref:`F5 Heat templates <heat:home>` can be used to provision resources and BIG-IP services in OpenStack clouds. F5's templates use the OpenStack HOT template format; they can be used in conjunction with `F5 iApps® <https://devcentral.f5.com/wiki/iApp.HomePage.ashx>`_, a user-customizable framework for deploying applications.
+The F5 Heat templates can be used to provision resources and BIG-IP services in OpenStack clouds. F5's templates use the OpenStack HOT template format; they can be used in conjunction with `F5 iApps® <https://devcentral.f5.com/wiki/iApp.HomePage.ashx>`_, a user-customizable framework for deploying applications.
 
-The F5 Heat templates come in two flavors: :ref:`supported <heat:f5-supported_home>` and :ref:`unsupported <heat:unsupported_home>`. All F5 Heat templates can be downloaded from the F5 Heat :ref:`docs site <heat:home>`.
+The F5 Heat templates come in two flavors: :ref:`supported <heat:f5-supported_home>` and :ref:`unsupported <heat:unsupported_home>`. All F5 Heat templates can be downloaded from the F5 Heat :ref:`docs site <heat:home>` or GitHub repo.
 
 .. warning::
 
     F5 provides limited support for :ref:`supported <heat:f5-supported_home>` templates, while :ref:`unsupported <heat:unsupported_home>` templates are considered to be 'use-at-your-own-risk'.
-    
 
 
+.. seealso::
+
+    * `f5-openstack-heat on GitHub <https://github.com/F5Networks/f5-openstack-heat>`_
+    * :ref:`F5 Heat Docs Home <heat:home>`
+    * :ref:`F5 Heat User Guide <heat:heat-user-guide>`
 
 

--- a/docs/project_index.rst
+++ b/docs/project_index.rst
@@ -44,7 +44,7 @@ The F5 OpenStack service provider driver -- also referred to as the F5 LBaaSv2 d
 f5-openstack-agent
 ------------------
 
-The F5 agent provides OpenStack users with access to the robust set of `BIG-IP® LTM® <https://f5.com/products/modules/local-traffic-manager>`_ services. It uses the `f5-sdk <f5sdk:F5 Python SDK Documentation>` to translate messaging calls from OpenStack to iControl® REST calls that are understood by BIG-IP devices.
+The F5 agent provides OpenStack users with access to the robust set of `BIG-IP® LTM® <https://f5.com/products/modules/local-traffic-manager>`_ services. It uses the :ref:`f5-sdk <f5sdk:F5 Python SDK Documentation>` to translate messaging calls from OpenStack to iControl® REST calls that are understood by BIG-IP devices.
 
 In the future, the agent may also provide the means for using such OpenStack services as `FWaaS <https://wiki.openstack.org/wiki/Neutron/FWaaS>`_ and `VPNaaS <https://wiki.openstack.org/wiki/Neutron/VPNaaS>`_ in conjunction with BIG-IP devices.
 


### PR DESCRIPTION
@mattgreene 
@swormke 

#### What issues does this address?
Fixes #145, #138

#### What's this change do?
- refactors the home page as previously discussed
- adds a new, separate project index page
- contains the new 'for developers' section

#### Where should the reviewer start?

View the docs in the test rtd site at http://docs-dev.readthedocs.io/en/feature.docs-index/. 

#### Any background context?

