### PR TITLE
Add support for BIG-IP 13.0.x

### DIFF
--- a/docs/releases_and_versioning.rst
+++ b/docs/releases_and_versioning.rst
@@ -18,24 +18,24 @@ F5/OpenStack Compatibility -- LBaaSv2
       - 8.x
       - | 11.5.2+
         | 11.6.x
-        | 12.0.x
         | 12.1.x
+        | 13.0.x
       - 6, 7
       - 12, 14
     * - Mitaka
       - 9.x
       - | 11.5.2+
         | 11.6.x
-        | 12.0.x
         | 12.1.x
+        | 13.0.x
       - 6, 7
       - 12, 14
     * - Newton
       - N/A
       - | 11.5.2+
         | 11.6.x
-        | 12.0.x
         | 12.1.x
+        | 13.0.x
       - 6, 7
       - 12, 14
 
@@ -59,8 +59,8 @@ F5/OpenStack Compatibility -- Heat
       - 9.x
       - 9.x
     * - Newton
-      - N/A
-      - N/A
+      - 10.x
+      - 10.x
 
 
 F5/OpenStack Distribution Platform Compatibility


### PR DESCRIPTION
@mattgreene @jputrino 

#### What issues does this address?
Fixes #206

#### What's this change do?
Added 13.0.x support and removed 12.0.x

#### Where should the reviewer start?

#### Any background context?
We need to document our support for 13.0.x BIG-IP versions.
