### PR TITLE
merge partner and support matrix updates to Mitaka

### DIFF
--- a/docs/partners.rst
+++ b/docs/partners.rst
@@ -28,6 +28,12 @@ Each of F5's OpenStack distribution partners provides comprehensive documentatio
     * - `Mirantis OpenStack v7.0 <https://docs.mirantis.com/openstack/fuel/fuel-7.0/>`_
       - F5 LBaaSv1
       - Kilo
+    * - `RedHat OpenStack Platform v9 <https://access.redhat.com/documentation/en/red-hat-openstack-platform/?version=9>`_
+      - F5 LBaaSv2
+      - Mitaka
+    * - `RedHat OpenStack Platform v8 <https://access.redhat.com/documentation/en/red-hat-openstack-platform/?version=8>`_
+      - F5 LBaaSv2
+      - Liberty
     * - `RedHat OpenStack Platform v7 <https://access.redhat.com/documentation/en/red-hat-openstack-platform/?version=7>`_
       - F5 LBaaSv1
       - Kilo

--- a/docs/releases_and_versioning.rst
+++ b/docs/releases_and_versioning.rst
@@ -18,24 +18,24 @@ F5/OpenStack Compatibility -- LBaaSv2
       - 8.x
       - | 11.5.2+
         | 11.6.x
-        | 12.0.x
         | 12.1.x
+        | 13.0.x
       - 6, 7
       - 12, 14
     * - Mitaka
       - 9.x
       - | 11.5.2+
         | 11.6.x
-        | 12.0.x
         | 12.1.x
+        | 13.0.x
       - 6, 7
       - 12, 14
     * - Newton
       - N/A
       - | 11.5.2+
         | 11.6.x
-        | 12.0.x
         | 12.1.x
+        | 13.0.x
       - 6, 7
       - 12, 14
 
@@ -59,8 +59,8 @@ F5/OpenStack Compatibility -- Heat
       - 9.x
       - 9.x
     * - Newton
-      - N/A
-      - N/A
+      - 10.x
+      - 10.x
 
 
 F5/OpenStack Distribution Platform Compatibility


### PR DESCRIPTION
@mattgreene FYI

#### What issues does this address?
N/A

#### What's this change do?
Merges updates to the partner certifications table and the BIG-IP support matrix into the Mitaka branch (after resolving merge conflicts).

#### Where should the reviewer start?
N/A

#### Any background context?
