### PR TITLE
Stable/newton

### DIFF
--- a/docs/partners.rst
+++ b/docs/partners.rst
@@ -28,6 +28,12 @@ Each of F5's OpenStack distribution partners provides comprehensive documentatio
     * - `Mirantis OpenStack v7.0 <https://docs.mirantis.com/openstack/fuel/fuel-7.0/>`_
       - F5 LBaaSv1
       - Kilo
+    * - `RedHat OpenStack Platform v9 <https://access.redhat.com/documentation/en/red-hat-openstack-platform/?version=9>`_
+      - F5 LBaaSv2
+      - Mitaka
+    * - `RedHat OpenStack Platform v8 <https://access.redhat.com/documentation/en/red-hat-openstack-platform/?version=8>`_
+      - F5 LBaaSv2
+      - Liberty
     * - `RedHat OpenStack Platform v7 <https://access.redhat.com/documentation/en/red-hat-openstack-platform/?version=7>`_
       - F5 LBaaSv1
       - Kilo

--- a/docs/releases_and_versioning.rst
+++ b/docs/releases_and_versioning.rst
@@ -19,6 +19,7 @@ F5/OpenStack Compatibility -- LBaaSv2
       - | 11.5.2+
         | 11.6.x
         | 12.1.x
+        | 13.0.x
       - 6, 7
       - 12, 14
     * - Mitaka
@@ -26,6 +27,7 @@ F5/OpenStack Compatibility -- LBaaSv2
       - | 11.5.2+
         | 11.6.x
         | 12.1.x
+        | 13.0.x
       - 6, 7
       - 12, 14
     * - Newton
@@ -33,6 +35,7 @@ F5/OpenStack Compatibility -- LBaaSv2
       - | 11.5.2+
         | 11.6.x
         | 12.1.x
+        | 13.0.x
       - 6, 7
       - 12, 14
 


### PR DESCRIPTION
@mattgreene FYI

#### What issues does this address?
N/A

#### What's this change do?
Merges updates to the partner certs table and BIG-IP support matrix forward to stable/newton.

#### Where should the reviewer start?
N/A

#### Any background context?
