### PR TITLE
update travis.yaml 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ deploy:
     branch: v1
     repo: F5Networks/f5-openstack-docs
   script:
-  - ./scripts/deploy-docs.sh publish-cloud-docs-to-prod openstack latest
+  - ./scripts/deploy-docs.sh publish-cloud-docs-to-prod openstack v1
 notifications:
  slack:
   rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,7 @@ deploy:
 - provider: script
   skip_cleanup: true
   on:
-    branch: master
-    repo: F5Networks/f5-openstack-docs
-  script:
-  - ./scripts/deploy-docs.sh publish-cloud-docs-to-prod openstack latest
-deploy:
-- provider: script
-  skip_cleanup: true
-  on:
-    branch: master
+    branch: v1
     repo: F5Networks/f5-openstack-docs
   script:
   - ./scripts/deploy-docs.sh publish-cloud-docs-to-prod openstack latest


### PR DESCRIPTION

#### What issues does this address?
Fixes N/A
...

#### What's this change do?
Travis was previously configured to deploy to clouddocs from master. This is incorrect. I have removed the duplicate deploy section and replaced 'master' with 'v1' in the conditions. This ensures that docs will publish to clouddocs on commits to the release branch ('v1') only.

#### Where should the reviewer start?

#### Any background context?
