### PR TITLE
Add Cisco OpFlex solution docs

### DIFF
--- a/docs/_static/config_examples/f5-openstack-agent_opflex.ini
+++ b/docs/_static/config_examples/f5-openstack-agent_opflex.ini
@@ -1,0 +1,589 @@
+###############################################################################
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+#                   ############
+#                 ################
+#               ###/ _ \###|     |#
+#              ###| |#| |##| |######
+#             ####| |######| |######
+#             ##|     |####\    \###    AGILITY YOUR WAY!
+#             ####| |#########| |###
+#             ####| |#########| |##
+#              ###| |########/ /##
+#               #|    |####|  /##
+#                ##############
+#                 ###########
+#
+#                  NETWORKS
+#
+###############################################################################
+#
+[DEFAULT]
+# Show debugging output in log (sets DEBUG log level output).
+debug = True
+# The LBaaS agent will resync its state with Neutron to recover from any
+# transient notification or rpc errors. The interval is number of
+# seconds between attempts.
+#
+periodic_interval = 10
+#
+# How often should the agent throw away its service cache and
+# resync assigned services with the neutron LBaaS plugin.
+#
+service_resync_interval = 300
+#
+###############################################################################
+#  Environment Settings
+###############################################################################
+#
+# Since many TMOS object names must start with an alpha character
+# the environment_prefix is used to prefix all service objects.
+#
+# Objects created on the BIG-IP by this agent will have their names prefixed
+# by an environment string. This allows you set this string.  The default is
+# 'Project'.
+#
+# WARNING - you should only set this before creating any objects.  If you change
+# it with established objects, the objects created with an alternative prefix,
+# will no longer be associated with this agent and all objects in neutron
+# and on the the BIG-IP associated with the old environment will need to be managed
+# manually.
+#
+environment_prefix = '<my_prefix>'
+#
+# An additional function of differentiated environments is the ability
+# for the agent to collect capacity data and return that to the scheduler
+# through configuration data. The agent will return one configuration
+# item called  environment_capacity_score. The score is the highest capacity
+# recorded on several collected statistics specified in the capacity_policy
+# setting. The capacity_policy is a dictionary where the key is the
+# metric name and the value is the max allowed value for that metric.
+# The score is determined simply by dividing the metric collected by
+# the max for that metric specified in the capacity_policy.
+#
+# When multiple environemnt_group_number designated group of agents are
+# available, and a service is created where the services' tenant is not
+# associated with a group, the scheduler will try to assign the service
+# to the group with the last recorded lowest environment_capacity_score.
+# If the services' tenant was associated with an agent where the
+# environment_group_number for all agents in the group are above capacity,
+# the new service will be associated with another group where capacity
+# is under the limit.
+#
+# WARNING - If you set the capacity_policy with a differentiated
+# environment, and all agents in all groups are at capacity, services
+# will no long be provisioned, but return errors.
+#
+# The following metrics are implemented by the icontrol_driver.iControlDriver:
+#
+# throughput - total throughput in bps of the TMOS devices
+# inbound_throughput - throughput in bps inbound to TMOS devices
+# outbound_throughput - throughput in bps outbound from TMOS devices
+# active_connections - number of concurrent active actions on a TMOS device
+# tenant_count - number of tenants associated with a TMOS device
+# node_count - number of nodes provisioned on a TMOS device
+# route_domain_count - number of route domains on a TMOS device
+# vlan_count - number of VLANs on a TMOS device
+# tunnel_count - number of GRE and VxLAN overlay tunnels on a TMOS device
+# ssltps - the current measured SSL TPS count on a TMOS device
+# clientssl_profile_count - the number of clientside SSL profiles defined
+#
+# You can specify one or multiple metrics.
+#
+# capacity_policy = throughput:1000000000, active_connections: 250000, route_domain_count: 512, tunnel_count: 2048
+#
+###############################################################################
+#  Static Agent Configuration Setting
+###############################################################################
+#
+# Statically set the agent ID used to identify this agent with
+# Neutron.
+#
+# The agent ID is used to identify this instance of
+# the agent for scheduling and messaging. If not set, the
+# agent ID will be automatically populated with the host name
+# of host running the agent appended with a hash of the
+# environment_prefix and the first iControl endpoint.
+#
+# This parameter is required to integrate with Cisco ACI/OpFlex
+agent_id = "f5-lbaasv2"
+#
+# Static configuration data to sent back to the plugin. This can be used
+# on the plugin side of neutron to provide agent identification for custom
+# pool to agent scheduling. This should be a single or comma separated list
+# of name:value entries which will be sent in the agent's configuration
+# dictionary to neutron.
+#
+# static_agent_configuration_data = location:DFW1_R122_U9, service_contract:8675309, contact:jenny
+#
+###############################################################################
+#  Device Setting
+###############################################################################
+#
+# HA model
+#
+# Device can be required to be:
+#
+# standalone - single device no HA
+# pair - active/standby two device HA
+# scalen - active device cluster
+#
+# If the device is external, the devices must be onboarded for the
+# appropriate HA mode or else the driver will not provision devices
+#
+f5_ha_type = standalone
+#
+###############################################################################
+#  L2 Segmentation Mode Settings
+###############################################################################
+#
+# Device VLAN to interface and tag mapping
+#
+# For pools or VIPs created on networks with type VLAN we will map
+# the VLAN to a particular interface and state if the VLAN tagging
+# should be enforced by the external device or not.  This setting
+# is a comma separated list of the following format:
+#
+#    physical_network:interface_name:tagged, physical:interface_name:tagged
+#
+# where :
+#   physical_network corresponds to provider:physical_network attributes
+#   interface_name is the name of an interface or LAG trunk
+#   tagged is a boolean (True or False)
+#
+# If a network does not have a provider:physical_network attribute,
+# or the provider:physical_network attribute does not match in the
+# configured list, the 'default' physical_network setting will be
+# applied. At a minimum you must have a 'default' physical_network
+# setting.
+#
+# standalone example:
+#   f5_external_physical_mappings = default:1.1:True
+#
+# pair or scalen (1.1 and 1.2 are used for HA purposes):
+#   f5_external_physical_mappings = default:1.3:True
+#
+f5_external_physical_mappings = default:1.1:True
+#
+# VLAN device and interface to port mappings
+#
+# Some systems require the need to bind and prune VLANs ids
+# allowed to specific ports, often for security.
+#
+# An example would be if a LBaaS iControl endpoint is using
+# tagged VLANs. When a VLAN tagged network is added to a
+# specific BIG-IP device, the facing switch port will need
+# to allow traffic for that VLAN tag through to the BIG-IP's
+# port for traffic to flow.
+#
+# What is required is a software hook which allows the binding.
+# A vlan_binding_driver class needs to reference a subclass of the
+# VLANBindingBase class and provides the methods to bind and prune
+# VLAN tags to ports.
+#
+# vlan_binding_driver = f5.oslbaasv1agent.drivers.bigip.vlan_binding.NullBinding
+#
+# The interface_port_static_mappings allows for a JSON encoded dictionary
+# mapping BIG-IP devices and interfaces to corresponding ports. A port id can be
+# any string which is meaningful to a vlan_binding_driver. It can be a
+# switch_id and port, or it might be a neutron port_id.
+#
+# In addition to any static mappings, when the iControl endpoints
+# are initialized, all their TMM interfaces will be collect
+# for each device and neutron will be queried to see if which
+# device port_ids correspond to known neutron ports. If they do,
+# automatic entries for all mapped port_ids will be made referencing
+# the BIG-IP device name and interface and the neutron port_ids.
+#
+# interface_port_static_mappings = {"device_name_1":{"interface_ida":"port_ida","interface_idb":"port_idb"}, {"device_name_2":{"interface_ida":"port_ida","interface_idb":"port_idb"}}
+#
+# example:
+#
+# interface_port_static_mappings = {"bigip1":{"1.1":"switch1:g2/32","1.2":"switch1:g2/33"},"bigip2":{"1.1":"switch1:g3/32","1.2":"switch1:g3/33"}}
+#
+# Device Tunneling (VTEP) Self IPs
+#
+# This is the name of a BIG-IP self IP address to use for VTEP addresses.
+#
+# If no gre or vxlan tunneling is required, these settings should be
+# commented out or set to None.
+#
+#f5_vtep_folder = 'Common'
+#f5_vtep_selfip_name = '<self-ip_for_vtep>'
+#
+#
+# Tunnel types
+#
+# This is a comma separated list of tunnel types to report
+# as available from this agent as well as to send via tunnel_sync
+# rpc messages to compute nodes. This should match your ml2
+# network types on your compute nodes.
+#
+# If you are using only gre tunnels it should be:
+#
+# advertised_tunnel_types = gre
+#
+# If you are using only vxlan tunnels it should be:
+#
+# advertised_tunnel_types = vxlan
+#
+# If this agent could get both gre and vxlan tunnel networks:
+#
+# advertised_tunnel_types = gre,vxlan
+#
+# If you are using only vlans only it should be:
+#
+# advertised_tunnel_types =
+#
+# Static ARP population for members on tunnel networks
+#
+# This is a boolean True or False value which specifies
+# that if a Pool Member IP address is associated with a gre
+# or vxlan tunnel network, in addition to a tunnel fdb
+# record being added, that a static arp entry will be created to
+# avoid the need to learn the member's MAC address via flooding.
+#
+# NOTE: this is currently set to false b/c the static arp population
+# is not functioning correctly in the BIG-IP REST api.  See issues:
+# f5-openstack-agent issue #133 and
+# f5-common-python issue #495
+f5_populate_static_arp = False
+
+#
+# Device Tunneling (VTEP) self IPs
+#
+# This is a boolean entry which determines if the BIG-IP will use
+# L2 Population service to update its fdb tunnel entries. This needs
+# to be set up in accordance with the way the other tunnel agents are
+# set up.  If the BIG-IP agent and other tunnel agents don't match
+# the tunnel setup will not work properly.
+#
+l2_population = True
+#
+# Hierarchical Port Binding (HPB)
+#
+# If hierarchical networking is not required, these settings must be commented
+# out or set to None.
+# This section is required when using Cisco ACI/OpFlex & HPB
+#
+# Tell Neutron what "physnet" mapping is used to create tenant networks.
+# Restricts discovery of network segmentation ID to this specific physical network.
+f5_network_segment_physical_network = physnet1
+#
+# Periodically scan for disconected listeners (a.k.a virtual servers).  The
+# interval is number of seconds between attempts.
+#
+f5_network_segment_polling_interval = 10
+#
+# Maximum amount of time in seconds before a pending service gets moved into
+# error state.  Polling spacing is 10 seconds which is not yet configurable.
+#
+f5_pending_services_timeout = 60
+#
+###############################################################################
+#  L3 Segmentation Mode Settings
+###############################################################################
+#
+# Global Routed Mode - No L2 or L3 Segmentation on BIG-IP
+#
+# This setting will cause the agent to assume that all VIPs
+# and pool members will be reachable via global device
+# L3 routes, which must be already provisioned on the BIG-IPs.
+#
+# In f5_global_routed_mode, BIG-IP will not assume L2
+# adjacentcy to any neutron network, therefore no
+# L2 segementation between tenant services in the data plane
+# will be provisioned by the agent. Because the routing
+# is global, no L3 self IPs or SNATs will be provisioned
+# by the agent on behalf of tenants either. You must have
+# all necessary L3 routes (including TMM default routes)
+# provisioned before LBaaS resources are provisioned for tenants.
+#
+# WARNING: setting this mode to True will override
+# the use_namespaces, setting it to False, because only
+# one global routing space will used on the BIG-IP.  This
+# means overlapping IP addresses between tenants is no
+# longer supported.
+#
+# WARNING: setting this mode to True will override
+# the f5_snat_mode, setting it to True, because pool members
+# will never be considered L2 adjacent to the BIG-IP by
+# the agent. All member access will be via L3 routing, which
+# will need to be set up on the BIG-IP before LBaaS provisions
+# resources on behalf of tenants.
+#
+# WARNING: setting this mode to True will override the
+# f5_snat_addresses_per_subnet, setting it to 0 (zero).
+# This will force all VIPs to use AutoMap SNAT for which
+# enough Self IP will need to be pre-provisioned on the
+# BIG-IP to handle all pool member connections. The SNAT,
+# an L3 mechanism, will all be global without reference
+# to any specific tenant SNAT pool.
+#
+# WARNING: setting this mode will make the VIPs listen
+# on all provisioned L2 segments (All VLANs). This is
+# because no L2 information will be taken from
+# neutron, thus making the assumption that all VIP
+# L3 addresses will be globally routable without
+# segmentation at L2 on the BIG-IP.
+#
+f5_global_routed_mode = False
+#
+# Allow overlapping IP subnets across multiple tenants.
+# This creates route domains on big-ip in order to
+# separate the tenant networks.
+#
+# This setting is forced to False if
+# f5_global_routed_mode = True.
+#
+use_namespaces = True
+#
+# When use_namespaces is True there is normally only one route table
+# allocated per tenant. However, this limit can be increased by
+# changing the max_namespaces_per_tenant variable. This allows one
+# tenant to have overlapping IP subnets.
+#
+# Supporting multiple IP namespaces allows establishing multiple independent
+# IP routing topologies within one tenant project, which, for example,
+# can accomodate multiple testing environments in one project, with
+# each testing environment configured to use the same IP address
+# topology as each other test environment.
+#
+# From a practical point of view, allowing multiple IP namespaces
+# per tenant results in a more complicated configuration scheme
+# for big-ip and also allows a single tenant to consumes more
+# routing tables, which are a limited resource. In order to keep
+# a simple one-to-one strategy of one tenant to one route domain,
+# it is recommended that separate projects be used if possible to
+# establish a new routing namespace rather than allowing multiple route
+# domains within one tenant.
+#
+# If a tenant attempts to use a subnet that overlaps with an existing
+# subnet that is already in use in the existing route domain(s), and
+# this setting is not high enough to accomodate a new route domain to
+# handle the new subnet, then the relevant lbaas element (vip or pool member)
+# will be set to the error state.
+#
+max_namespaces_per_tenant = 1
+#
+# Dictates the strict isolation of the routing
+# tables.  If you set this to True, then all
+# VIPs and Members must be in the same tenant
+# or less they can't communicate.
+#
+# This setting is only valid if use_namespaces = True.
+#
+f5_route_domain_strictness = False
+#
+# SNAT Mode and SNAT Address Counts
+#
+# This setting will force the use of SNATs.
+#
+# If this is set to False, a SNAT will not
+# be created (routed mode) and the BIG-IP
+# will attempt to set up a floating self IP
+# as the subnet's default gateway address.
+# and a wild card IP forwarding virtual
+# server will be set up on member's network.
+# Setting this to False will mean Neutron
+# floating self IPs will not longer work
+# if the same BIG-IP device is not being used
+# as the Neutron Router implementation.
+#
+# This setting will be forced to True if
+# f5_global_routed_mode = True.
+#
+f5_snat_mode = True
+#
+# This setting will specify the number of snat
+# addresses to put in a snat pool for each
+# subnet associated with a created local self IP.
+#
+# Setting to 0 (zero) will set VIPs to AutoMap
+# SNAT and the device's local self IP will
+# be used to SNAT traffic.
+#
+# In scalen HA mode, this is the number of snat
+# addresses per active traffic-group at the time
+# a service is provisioned.
+#
+# This setting will be forced to 0 (zero) if
+# f5_global_routed_mode = True.
+#
+f5_snat_addresses_per_subnet = 1
+#
+# This setting will cause all networks to be
+# defined under the common partition on the
+# BIG-IP rather than offer the flexibility to
+# assign networks to different partitions..
+f5_common_networks = False
+#
+# This setting will cause all networks with
+# the router:external attribute set to True
+# to be created in the Common partition and
+# placed in route domain 0.
+f5_common_external_networks = True
+#
+#
+# Common Networks
+#
+# This setting contains a name value pair comma
+# separated list where if the name is a neutron
+# network id used for a vip or a pool member,
+# the network should not be created or deleted
+# on the BIG-IP, but rather assumed that the value
+# is the name of the network already created in
+# the Common partition with all L3 addresses
+# assigned to route domain 0.  This is useful
+# for shared networks which are already defined
+# on the BIG-IP prior to LBaaS configuration. The
+# network should not be managed by the LBaaS agent,
+# but can be used for VIPs or pool members
+#
+# If your Internet VLAN on your BIG-IP is named
+# /Common/external, and that corresponds to
+# Neutron uuid: 71718972-78e2-449e-bb56-ce47cc9d2680
+# then the entry would look like:
+#
+common_network_ids = <neutron-external-network-UUID>:external
+#
+# If you had multiple common networks, they are simply
+# comma seprated like this example:
+#
+# common_network_ids = 71718972-78e2-449e-bb56-ce47cc9d2680:external,396e06a0-05c7-4a49-8e86-04bb83d14438:vlan1222
+#
+# The default is no common networks defined
+#
+# L3 Bindings
+#
+# Some systems require the need to bind L3 addresses
+# to specific ports, often for security.
+#
+# An example would be if a LBaaS iControl endpoint is using
+# untagged VLANs and is a nova guest instance. By
+# default, neutron will attempt to apply security rule
+# for anti-spoofing which will not allow just any L3
+# address to be used on the neutron port. The answer is to
+# use allowed-address-pairs for the neutron port.
+#
+# What is required is a software hook which allows the binding.
+# l3_binding_driver needs to reference a subclass of the L3BindingBase
+# class and provides the methods to bind and unbind L3 address
+# to ports.
+#
+# l3_binding_driver = f5_openstack_agent.lbaasv2.drivers.bigip.l3_binding.AllowedAddressPairs
+#
+# The l3_binding_static_mappings allows for a JSON encoded dictionary
+# mapping neutron subnet ids to lists of L2 ports and devices which
+# require mapping. The entries for port and device mappings
+# vary between providers. They may look like a neutron port id
+# and a nova guest instance id.
+#
+# In addition to any static mappings, when the iControl endpoints
+# are initialized, all their TMM MAC addresses will be collect
+# and neutron will be queried to see if the MAC addresses
+# correspond to known neutron ports. If they do, automatic entries
+# for all mapped fixed_ips will be made referencing the ports id
+# and the ports device_id.
+#
+# l3_binding_static_mappings = 'subnet_a':[('port_a','device_a'),('port_b','device_b')], 'subnet_b':[('port_c','device_a'),('port_d','device_b')]
+#
+#
+#
+###############################################################################
+#  Device Driver Setting
+###############################################################################
+#
+f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver
+#
+#
+###############################################################################
+#  Device Driver - iControl Driver Setting
+###############################################################################
+#
+# icontrol_hostname is valid for external device type only.
+# this setting can be either a single IP address or a
+# comma separated list contain all devices in a device
+# service group.  For guest devices, the first fixed_address
+# on the first device interfaces will be used.
+#
+# If a single IP address is used and the HA model
+# is not standalone, all devices in the sync failover
+# device group for the hostname specified must have
+# their management IP address reachable to the agent.
+# If order to access devices' iControl interfaces via
+# self IPs, you should specify them as a comma-
+# separated list below.
+#
+icontrol_hostname = <ip-address_of_BIG-IP>
+#
+# If you are using vCMP with VLANs, you will need to configure
+# your vCMP host addresses, in addition to the guests addresses.
+# vCMP Host access is necessary for provisioning VLANs to a guest.
+# Use icontrol_hostname for vCMP guests and icontrol_vcmp_hostname
+# for vCMP hosts. The plug-in will automatically determine
+# which host corresponds to each guest.
+#
+# icontrol_vcmp_hostname = 192.168.1.245
+#
+# icontrol_username must be a valid Administrator username
+# on all devices in a device sync failover group.
+#
+icontrol_username = <my_username>
+#
+# icontrol_password must be a valid Administrator password
+# on all devices in a device sync failover group.
+#
+icontrol_password = <my_password>
+#
+###############################################################################
+# Certificate Manager
+###############################################################################
+# cert_manager = f5_openstack_agent.lbaasv2.drivers.bigip.barbican_cert.BarbicanCertManager
+#
+# Two authentication modes are supported for BarbicanCertManager:
+#   keystone_v2, and keystone_v3
+#
+#
+# Keystone v2 authentication:
+#
+# auth_version = v2
+# os_auth_url = http://localhost:5000/v2.0
+# os_username = admin
+# os_password = changeme
+# os_tenant_name = admin
+#
+#
+# Keystone v3 authentication:
+#
+auth_version = v3
+os_auth_url = http://localhost:5000/v3
+os_username = <my-os-username>
+os_password = <my-os-password>
+os_user_domain_name = default
+os_project_name = <my-os-project>
+os_project_domain_name = default
+#
+# Parent SSL profile name
+#
+# A client SSL profile is created for LBaaS listeners that use TERMINATED_HTTPS
+# protocol. You can define the parent profile for this profile by setting
+# f5_parent_ssl_profile. The profile created to support TERMINATTED_HTTPS will
+# inherit settings from the parent you define. This must be an existing profile,
+# and if it does not exist on your BIG-IP system the agent will use the default
+# profile, clientssl.
+f5_parent_ssl_profile = clientssl

--- a/docs/_static/reuse/applies-to-ALL.rst
+++ b/docs/_static/reuse/applies-to-ALL.rst
@@ -1,4 +1,4 @@
-.. sidebar:: Applies to:
+.. sidebar:: :fonticon:`fa fa-info-circle` Applies to:
 
    ====================    ===========================
    F5 LBaaS version(s)     OpenStack version(s)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -425,9 +425,10 @@ rst_epilog = '''
 .. |f5_driver_pip_url| replace:: git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver@v%(version_latest)s
 .. |version_latest| replace:: %(version_latest)s
 .. _Configure the F5 Agent for OpenStack Neutron: /products/openstack/agent/latest/index.html#configure-the-f5-openstack-agent
-.. _HPE Helion OpenStack: https://docs.hpcloud.com/hrc/helionReady.html
+.. _HPE Helion OpenStack: https://www.hpe.com/us/en/software/openstack-cloud-iaas.html
 .. _Mirantis OpenStack: https://www.mirantis.com/partners/f5-networks/
 .. _RedHat OpenStack Platform: https://access.redhat.com/ecosystem/software/1446683
+.. _OpenStack Nova: https://docs.openstack.org/nova/latest
 ''' % {
   'openstack_release': openstack_release,
   'openstack_release_l': openstack_release.lower(),

--- a/docs/lbaas/index.rst
+++ b/docs/lbaas/index.rst
@@ -1,3 +1,7 @@
+.. index::
+   single: openstack; concept
+   triple: lbaas; agent; driver
+
 .. _openstack-lbaas-home:
 
 F5 Integration for OpenStack Neutron LBaaS
@@ -31,7 +35,7 @@ It picks up Neutron LBaaS calls from the RPC messaging queue and assigns them to
 .. figure:: /_static/media/f5-lbaas-architecture.png
    :align: center
    :scale: 100%
-   :alt: Diagram showing the architecture of the F5 Integration for OpenStack Neutron LBaaS. A user issues a neutron lbaas command; the F5 LBaaSv2 driver assigns the task from the Neutron RPC messaging queue to the F5 Agent for OpenStack Neutron. The BIG-IP Controller periodically reports its status to the Neutron database.
+   :alt: Diagram showing the architecture of the F5 Integration for OpenStack Neutron LBaaS. A user issues a neutron lbaas command; the F5 LBaaSv2 driver assigns the task from the Neutron RPC messaging queue to the F5 Agent for OpenStack Neutron. The F5 Agent periodically reports its status to the Neutron database.
 
    F5 Integration for OpenStack Neutron LBaaS Architecture
 
@@ -45,12 +49,14 @@ It receives tasks from the Neutron RPC messaging queue, converts them to `iContr
 .. figure:: /_static/media/f5-lbaas-agent-to-BIG-IP.png
    :align: center
    :scale: 100%
-   :alt: Diagram showing the operation of the F5 Agent for OpenStack Neutron. A user issues a neutron lbaas command; the F5 LBaaSv2 driver assigns the task to the F5 Agent for OpenStack Neutron; the BIG-IP Controller sends the command to the BIG-IP device as an iControl REST API call to add or edit the requested object.
+   :alt: Diagram showing the operation of the F5 Agent for OpenStack Neutron. A user issues a neutron lbaas command; the F5 LBaaSv2 driver assigns the task to the F5 Agent for OpenStack Neutron; the F5 Agent sends the command to the BIG-IP device as an iControl REST API call to add or edit the requested object.
 
    F5 Agent for OpenStack Neutron traffic flow
 
 Key OpenStack Concepts
 ----------------------
+
+.. todo:: add provider networks section; need to note the supported network types (vlan, vxlan, gre, opflex) somewhere; could be in the agent repo instead
 
 .. _lbaas-agent-tenant-affinity:
 

--- a/docs/lbaas/set-up-agent-hpb.rst
+++ b/docs/lbaas/set-up-agent-hpb.rst
@@ -1,0 +1,211 @@
+.. index::
+   :pair: task, lbaas
+   :pair: task, F5 agent
+
+
+How to set up the F5 Agent for Hierarchical Port Binding
+========================================================
+
+Overview
+--------
+
+This guide demonstrates how to set up the |oslbaas| to use standard :ref:`Hierarchical Port Binding <hpb>` (HPB) or to integrate the |agent| with a `Cisco ACI OpFlex network`_.
+
+Before you begin
+````````````````
+This document assumes that you already:
+
+- have a functional OpenStack cloud;
+- set up all networking components;
+- licensed and configured your BIG-IP device(s) for software-defined networking (SDN) (requires a Better or Best license);
+- :ref:`installed the F5 Agent and Driver <lbaas-quick-start>`;
+- :ref:`set up security groups for BIG-IP in OpenStack <security groups>`.
+
+.. important::
+
+   - If you're managing a BIG-IP device/cluster with multiple instances of the |agent| :ref:`running on different hosts <lbaas-agent-redundancy>`, each instance must use the same ``f5_network_segment_physical_network``.
+   - If you're using :ref:`differentiated service environments <lbaas-differentiated-service-env>`, every |agent| in a service group must use the same HPB settings.
+
+Tasks
+`````
+
+==================================================================   ==================================================
+Task                                                                 Description
+==================================================================   ==================================================
+:ref:`Set up the F5 Agent for standard HPB <agent-setup-hpb>`        Complete this section if you are using an SDN
+                                                                     controller **other than** Cisco APIC.
+------------------------------------------------------------------   --------------------------------------------------
+:ref:`Set up the F5 Agent for HPB with Cisco APIC & OpFlex`          Complete this section if you are using the |agent|
+                                                                     with Cisco APIC, `ACI`_ & `OpenStack OpFlex`_.
+------------------------------------------------------------------   --------------------------------------------------
+:ref:`Verify your setup <agent-verify-hpb>`.                         Create neutron lbaas objects in a specific
+                                                                     network segment to verify your setup.
+==================================================================   ==================================================
+
+.. _HPB settings:
+
+HPB settings
+------------
+
+========================================================================   ==================================================================
+Configuration Parameter                                                    Description
+========================================================================   ==================================================================
+``agent_id``                                                               Manually configures the F5 Agent's "host" name.
+
+                                                                           For Cisco `ACI`_: corresponds to the ``apic_switch`` parameter in
+                                                                           the :file:`ml2_conf_cisco_apic.ini` file; ensures correct mapping
+                                                                           for the ACI leaf port.
+------------------------------------------------------------------------   ------------------------------------------------------------------
+``f5_external_physical_mappings = default:1.1:True``                       *Default setting*; tells the |agent| that BIG-IP 1.1 is a
+                                                                           tagged interface connected to the external network
+                                                                           (``physnet1`` in the Cisco example).
+------------------------------------------------------------------------   ------------------------------------------------------------------
+``f5_network_segment_physical_network``                                    Activates HPB; tells Neutron what network segment you're going to
+                                                                           create tenant networks in (``physnet1`` in the Cisco example).
+
+                                                                           This should match a mapping used in the ``ml2_type_vlan`` section
+                                                                           of the `ML2 driver configuration file`_ (:file:`ML2_conf.ini`).
+------------------------------------------------------------------------   ------------------------------------------------------------------
+``f5_global_routed_mode = False``                                          *Default setting*; disables the |agent| `Global Routed Mode`_.
+------------------------------------------------------------------------   ------------------------------------------------------------------
+``common_network_ids = <neutron_uuid>:<BIG-IP_network_name>``              Tells the |agent| that a VLAN set up directly on the BIG-IP
+                                                                           device corresponds to a specific Neutron network.
+
+                                                                           For example:
+                                                                           ``cbbbe1f4-8000-4e8e-92e5-d758962fb26d:external``.
+========================================================================   ==================================================================
+
+
+.. _agent-setup-hpb:
+
+Set up standard HPB
+-------------------
+
+#. Edit the |agent| `configuration file`_:
+
+   .. include:: /_static/reuse/edit-agent-config-file.rst
+
+
+#. Set the :ref:`HPB settings` as appropriate for your environment.
+
+   .. code-block:: bash
+      :caption: Hierarchical Port Binding Example
+
+      ###############################################################################
+      #  L2 Segmentation Mode Settings
+      ###############################################################################
+      #
+      f5_external_physical_mappings = default:1.1:True
+      #
+      ...
+      f5_network_segment_physical_network = <name_of_neutron_network>
+      #
+      f5_network_segment_polling_interval = 10
+      #
+      f5_pending_services_timeout = 60
+      #
+      ###############################################################################
+      #  L3 Segmentation Mode Settings
+      ###############################################################################
+      #
+      f5_global_routed_mode = False
+      #
+
+.. index::
+   :triple: lbaas, cisco aci, F5 agent
+   :triple: lbaas, opflex, F5 agent
+
+.. _Set up the F5 Agent for HPB with Cisco APIC & OpFlex:
+
+Set up HPB with Cisco APIC/ACI & OpFlex on RedHat OSP
+-----------------------------------------------------
+
+.. note::
+
+   The information provided here supplements the `Cisco ACI with OpenStack OpFlex Deployment Guide for Red Hat`_.
+   It assumes you have already completed the deployment and network configuration steps in the Cisco Deployment Guide.
+
+   See the `Cisco APIC/ACI with OpFlex Use Case <understanding cisco aci opflex>`_ for more information about this deployment.
+
+#. `Configure the OpFlex ML2 Plugin to use Hierarchical Port Binding`_ :fonticon:`fa fa-external`
+
+#. Edit the |agent| `configuration file`_:
+
+   .. include:: /_static/reuse/edit-agent-config-file.rst
+
+#. Set the :ref:`HPB settings` as appropriate for your environment.
+
+.. important::
+
+   - The Cisco OpFlex plugin identifies the |agent| using the ``agent_ID`` configuration parameter.
+   - The |agent| ``f5_network_segment_physical_network`` configuration parameter corresponds to the Neutron external network segment where you want to create LBaaS objects.
+     In the example provided here (and in the Cisco deployment guide), ``physnet1`` is the name of this segment.
+
+.. code-block:: bash
+   :caption: Example F5 Agent configurations for Cisco ACI
+
+   ###############################################################################
+   #  Static Agent Configuration Setting
+   ###############################################################################
+   #
+   agent_id = "f5-lbaasv2"
+   #
+   ...
+   ###############################################################################
+   #  L2 Segmentation Mode Settings
+   ###############################################################################
+   #
+   f5_external_physical_mappings = default:1.1:True
+   #
+   ...
+   f5_network_segment_physical_network = physnet1
+   #
+   f5_network_segment_polling_interval = 10
+   #
+   f5_pending_services_timeout = 60
+   #
+   ###############################################################################
+   #  L3 Segmentation Mode Settings
+   ###############################################################################
+   #
+   f5_global_routed_mode = False
+   #
+
+:fonticon:`fa fa-download` :download:`Download the full example </_static/config_examples/f5-openstack-agent_opflex.ini>`
+
+
+.. _agent-verify-hpb:
+
+Verify your deployment
+----------------------
+
+#. Create LBaaS objects in Neutron
+
+   #. Create a new Neutron load balancer for a subnet in the ``f5_network_segment_physical_network`` set up for the |agent|.
+   #. Create one (1) listener on a different subnet.
+   #. Create one (1) pool
+   #. Create two (2) pool members.
+
+   .. code-block:: console
+
+      neutron lbaas-loadbalancer-create --name lb1 --vip-address <ip_address> <subnet_uuid>
+      neutron lbaas-listener-create --name vs1 --loadbalancer lb1 --protocol HTTP --protocol-port 80
+      neutron lbaas-pool-create --name pool1 --protocol HTTP --lb-algorithm ROUND_ROBIN --listener vs1
+      neutron lbaas-member-create --address <ip_address> --protocol-port 80 --subnet <subnet_uuid> --name member1 pool1
+
+#. Use the BIG-IP configuration utility to verify creation of the partition, virtual server, pool, and pool members.
+
+   - :menuselection:`Local Traffic -> Virtual Servers -> Virtual Server List`
+   - :menuselection:`Local Traffic -> Pools -> Pool List`
+   - Click the ``2`` in the :guilabel:`Members` column to view the pool members.
+
+You should now be able to send HTTP traffic to the listener (the BIG-IP virtual server) and load balance the traffic between the two pool members.
+
+
+.. _Cisco ACI OpFlex network: https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/1-x/openstack/b_ACI_with_OpenStack_OpFlex_Architectural_Overview/b_ACI_with_OpenStack_OpFlex_Architectural_Overview_chapter_010.html
+.. _ACI: http://www.cisco.com/c/en/us/solutions/data-center-virtualization/application-centric-infrastructure/index.html
+.. _OpenStack OpFlex: http://openstack-opflex.ciscolive.com/pod1
+.. _Cisco ACI with OpenStack OpFlex Deployment Guide for Red Hat: http://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/1-x/openstack/b_ACI_with_OpenStack_OpFlex_Deployment_Guide_for_Red_Hat/b_ACI_with_OpenStack_OpFlex_Deployment_Guide_for_Red_Hat_appendix_0101.html#id_46535
+.. _Configure the OpFlex ML2 Plugin to use Hierarchical Port Binding: https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/1-x/openstack/b_ACI_with_OpenStack_OpFlex_Deployment_Guide_for_Red_Hat/b_ACI_with_OpenStack_OpFlex_Deployment_Guide_for_Red_Hat_appendix_0101.html#id_46535
+.. _Example of the ml2_conf_cisco_apic.ini file: https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/1-x/openstack/b_ACI_with_OpenStack_OpFlex_Deployment_Guide_for_Red_Hat/b_ACI_with_OpenStack_OpFlex_Deployment_Guide_for_Red_Hat_appendix_0101.html#id_46545
+.. _ML2 driver configuration file: https://wiki.openstack.org/wiki/Ml2_conf.ini_File

--- a/docs/master_toc.rst
+++ b/docs/master_toc.rst
@@ -29,6 +29,7 @@
    lbaas/differentiated-service-environments
    lbaas/capacity-based-scaleout
    lbaas/hierarchical-port-binding
+   lbaas/set-up-agent-hpb
    F5 LBaaS v1 integration (EOTS) <http://clouddocs.f5.com/products/openstack/lbaasv1/master>
 
 .. toctree::

--- a/docs/tutorials/set-up-bigip-security-groups.rst
+++ b/docs/tutorials/set-up-bigip-security-groups.rst
@@ -1,0 +1,66 @@
+.. index::
+   :pair: BIG-IP, lbaas
+   :pair: BIG-IP, heat
+   :pair: BIG-IP, security
+   :single: OpenStack security groups
+
+.. _setup-access-security:
+
+Set up access and security groups for BIG-IP devices
+====================================================
+
+To use BIG-IP device(s) in an OpenStack cloud, you'll need to `configure access and security groups`_.
+
+.. _ssh keys:
+
+SSH Keys
+--------
+
+.. hint::
+
+   Follow the links below to view the appropriate topics in the OpenStack documentation.
+
+Before deploying BIG-IP Virtual Edition "over-the-cloud" as an `OpenStack Nova`_ instance, add or import an SSH key-pair.
+The key pair allows you to access the management console for the BIG-IP VE instance.
+
+- `Manage SSH keys using OpenStack Horizon`_. :fonticon:`fa fa-external`
+- `Manage SSH keys using the OpenStack CLI`_. :fonticon:`fa fa-external`
+
+.. _security groups:
+
+Security Groups
+---------------
+
+You'll need to create a security group and rules that allow traffic to pass through BIG-IP devices from `OpenStack Neutron`_ networks.
+Specifically, the security rules should allow the ICMP protocol and standard ports used by BIG-IP devices: 22, 80, and 443.
+
+- `Create security groups with OpenStack Heat`_ using templates from the F5 Unsupported HOT library.
+- `Create security groups in OpenStack Horizon`_. :fonticon:`fa fa-external`
+- `Create security groups using the OpenStack CLI`_. :fonticon:`fa fa-external`
+- `Create security group rules using the OpenStack CLI`_. :fonticon:`fa fa-external`
+
+.. code-block:: console
+   :caption: Example - create a security group and rules using the OpenStack CLI
+
+   openstack security group create --project <my_project> --description "security group for BIG-IP devices" bigip
+   openstack security group rule create --protocol icmp --ingress bigip
+   openstack security group rule create --protocol tcp --dst-port 22 --ingress bigip
+   openstack security group rule create --protocol tcp --dst-port 80 --ingress bigip
+   openstack security group rule create --protocol tcp --dst-port 443 --ingress bigip
+
+If you're using VXLAN and/or GRE, create the following rule(s):
+
+.. code-block:: console
+
+   neutron security group rule create --protocol udp --dst-port 4789 --ingress bigip
+   neutron security group rule create --protocol gre --ingress bigip
+
+
+
+.. _configure access and security groups: https://docs.openstack.org/horizon/latest/user/configure-access-and-security-for-instances.html
+.. _Manage SSH keys using OpenStack Horizon: https://docs.openstack.org/horizon/latest/user/configure-access-and-security-for-instances.html#keypair-add
+.. _Manage SSH keys using the OpenStack CLI: https://docs.openstack.org/python-openstackclient/latest/cli/command-objects/keypair.html
+.. _Create security groups with OpenStack Heat:
+.. _Create security groups in OpenStack Horizon:
+.. _Create security groups using the OpenStack CLI: https://docs.openstack.org/python-openstackclient/latest/cli/command-objects/security-group.html
+.. _Create security group rules using the OpenStack CLI: https://docs.openstack.org/python-openstackclient/latest/cli/command-objects/security-group-rule.html


### PR DESCRIPTION
@mattgreene 

#### What issues does this address?
Fixes #205 

#### What's this change do?
Refactors the hierarchical port binding doc into a concept and a task; both add information regarding the Cisco ACI/OpFlex deployment.

#### Where should the reviewer start?
View the changes inline below or view the staged documentation.
https://s3-us-west-2.amazonaws.com/staging-c2ub89n2qjgt1/cloud/openstack/feature-ciscoACI/lbaas/hierarchical-port-binding.html
https://s3-us-west-2.amazonaws.com/staging-c2ub89n2qjgt1/cloud/openstack/feature-ciscoACI/lbaas/set-up-agent-hpb.html

#### Any background context?
