### PR TITLE
Fixes #240- location of f5.tgz is incorrect

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -333,7 +333,7 @@ texinfo_documents = [
 #    'http://f5-sdk.readthedocs.io/en/latest/', None),
 #    }
 
-f5_lbaasv2_driver_shim_version = '10.1.0'
+f5_lbaasv2_driver_shim_version = '10.0.0'
 f5_lbaasv2_driver_shim_url = '\https://github.com/F5Networks/neutron-lbaas/releases/download/v%s/f5.tgz' % f5_lbaasv2_driver_shim_version
 # F5 SDK release version should be set here
 f5_sdk_version = '2.3.3'


### PR DESCRIPTION
@russokj 

#### What issues does this address?
Fixes #240 

#### What's this change do?
Fixes the location of the f5.tgz file containing the F5 service provider package for Neutron.

#### Where should the reviewer start?

#### Any background context?
The version was accidentally updated with the last release of the lbaasv2-driver, which was v10.1.0.