### PR TITLE
Fixes #241 - bad links for examples

### DIFF
--- a/docs/lbaas/quick-reference.rst
+++ b/docs/lbaas/quick-reference.rst
@@ -71,13 +71,16 @@ Tasks
 
 #. Set up the |agent|.
 
-   Sample configuration files:
+   Sample configuration files for download:
 
-   * `Global Routed Mode example </products/openstack/agent/_static/config_examples/f5-openstack-agent.grm.ini>`_
-   * `GRE example </products/openstack/agent/_static/config_examples/f5-openstack-agent.gre.ini>`_ [#licensing]_
-   * `VLAN example </products/openstack/agent/_static/config_examples/f5-openstack-agent.vlan.ini>`_
-   * `VXLAN example </products/openstack/agent/_static/config_examples/f5-openstack-agent.vxlan.ini>`_ [#licensing]_
+   * :agent:`Global Routed Mode example <_static/config_examples/f5-openstack-agent.grm.ini>`
+   * :agent:`GRE example <_static/config_examples/f5-openstack-agent.gre.ini>` [#licensing]_
+   * :agent:`VLAN example <_static/config_examples/f5-openstack-agent.vlan.ini>`
+   * :agent:`VXLAN example <_static/config_examples/f5-openstack-agent.vxlan.ini>` [#licensing]_
 
+   .. seealso::
+
+      `View the examples in the f5-openstack-agent repo on GitHub <https://github.com/F5Networks/f5-openstack-agent/tree/master/docs/_static/config_examples>`_.
 
 #. Start the |agent|.
 


### PR DESCRIPTION
@<reviewer_id>
#### What issues does this address?
Fixes #241 

#### What's this change do?
Fixes the links to the example .ini files for the agent. The links were missing the version ("latest") from the URL. They're now using the sphinx extlinks formatting.

I also added a link to the config_examples directory in the f5-openstack-agent GitHub repo.

#### Where should the reviewer start?

#### Any background context?
