### PR TITLE
Add title to glossary

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,5 +1,10 @@
 :orphan: true
 
+.. _glossary:
+
+Glossary
+========
+
 .. glossary::
    :sorted:
 


### PR DESCRIPTION
Greetings, 
Coveo (search) testing has found this page is showing up in search and browser as <no title>. 

   https://clouddocs.f5.com/cloud/openstack/v1/glossary.html

To fix and close their bug, I've added 'Glossary' as a title. Feel free to change or to delete this file if not needed.

Thank you!
Kevin